### PR TITLE
Update nvcr.io/hpc/autodock to 2020.06-x86_64

### DIFF
--- a/registry/nvcr.io/hpc/autodock/container.yaml
+++ b/registry/nvcr.io/hpc/autodock/container.yaml
@@ -1,14 +1,18 @@
 docker: nvcr.io/hpc/autodock
+url: https://ngc.nvidia.com/catalog/containers/hpc:autodock
+maintainer: '@vsoch'
+description: The AutoDock-GPU Suite is a growing collection of methods for computational
+  docking and virtual screening, for use in structure-based drug discovery and exploration
+  of the basic mechanisms of biomolecular structure and function. More info on AutoDock-GPU
+  be located at https://ccsb.scripps.edu/autodock/ and https://github.com/ccsb-scripps/AutoDock-GPU#usage.
 latest:
-  "2020.06": "sha256:6170944542063c7417343bec5e4001239e4ce113c2faf7f5824cb20a08373d9c"
+  2020.06-x86_64: sha256:0bc28fe0b15b172241f785079782447251139ad0ef0b978f3f1483d5caa9e56d
 tags:
-  "2020.06": "sha256:6170944542063c7417343bec5e4001239e4ce113c2faf7f5824cb20a08373d9c"
+  "2020.06": sha256:6170944542063c7417343bec5e4001239e4ce113c2faf7f5824cb20a08373d9c
+  2020.06-x86_64: sha256:0bc28fe0b15b172241f785079782447251139ad0ef0b978f3f1483d5caa9e56d
 filter:
-  - "20*"
-maintainer: "@vsoch"
-url: "https://ngc.nvidia.com/catalog/containers/hpc:autodock"
-description: "The AutoDock-GPU Suite is a growing collection of methods for computational docking and virtual screening, for use in structure-based drug discovery and exploration of the basic mechanisms of biomolecular structure and function. More info on AutoDock-GPU be located at https://ccsb.scripps.edu/autodock/ and https://github.com/ccsb-scripps/AutoDock-GPU#usage."
+- 20*
 aliases:
-  - name: autodock-gpu
-    command: /opt/AutoDock-GPU/bin/autodock_gpu_128wi
-    options: "--nv"
+- name: autodock-gpu
+  command: /opt/AutoDock-GPU/bin/autodock_gpu_128wi
+  options: --nv


### PR DESCRIPTION
Update nvcr.io/hpc/autodock to 2020.06-x86_64