### PR TITLE
Update ghcr.io/autamus/qhull to 2020.1

### DIFF
--- a/registry/ghcr.io/autamus/qhull/container.yaml
+++ b/registry/ghcr.io/autamus/qhull/container.yaml
@@ -1,11 +1,13 @@
 docker: ghcr.io/autamus/qhull
-latest:
-  "latest": "sha256:9391b171dddd337e97eb193e6501a3a11a0ca19da056b6d9a17b27667f105b61"
-tags:
-  "latest": "sha256:9391b171dddd337e97eb193e6501a3a11a0ca19da056b6d9a17b27667f105b61"
-maintainer: "@vsoch"
 url: https://github.com/orgs/autamus/packages/container/package/qhull
-description: "Snappy (previously known as Zippy) is a fast data compression and decompression library written in C++ by Google based on ideas from LZ77 and open-sourced in 2011."
+maintainer: '@vsoch'
+description: Snappy (previously known as Zippy) is a fast data compression and decompression
+  library written in C++ by Google based on ideas from LZ77 and open-sourced in 2011.
+latest:
+  "2020.1": sha256:9391b171dddd337e97eb193e6501a3a11a0ca19da056b6d9a17b27667f105b61
+tags:
+  "2020.1": sha256:9391b171dddd337e97eb193e6501a3a11a0ca19da056b6d9a17b27667f105b61
+  latest: sha256:9391b171dddd337e97eb193e6501a3a11a0ca19da056b6d9a17b27667f105b61
 aliases:
   qconvex: /opt/view/bin/qconvex
   qdelaunay: /opt/view/bin/qdelaunay


### PR DESCRIPTION
Update ghcr.io/autamus/qhull to 2020.1