### PR TITLE
Fixing missing container url in docgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - container url does not render in docs (0.0.23)
  - addition of tcl modules, removal of un-needed database (0.0.22)
  - first update of all containers, and bugfix to pull (0.0.21)
  - allowing for a custom container base, container_base (0.0.2)

--- a/shpc/main/modules.py
+++ b/shpc/main/modules.py
@@ -195,7 +195,7 @@ class ModuleBase(BaseClient):
             aliases=aliases,
             versions=config.tags.keys(),
             github_url=github_url,
-            url=config.url,
+            container_url=config.url,
             prefix=self.settings.module_exc_prefix,
             creation_date=datetime.now(),
             name=module_name,

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
The url variable should be container_url so the link shows up in the library pages!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>