### PR TITLE
Adding support for custom environment file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The versions coincide with releases on pip. Only major versions will be released
  - adding namespaces to make module install, show, inspect easier (0.0.24)
  - added support for env section to render to bound environment file
  - added support for container features like gpu
+ - allowing for a `container:tag` convention to be used for commands.
  - list defaults to showing modules/tags one per line, unless --short used
  - container url does not render in docs (0.0.23)
  - addition of tcl modules, removal of un-needed database (0.0.22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The versions coincide with releases on pip. Only major versions will be released
  - adding namespaces to make module install, show, inspect easier (0.0.24)
  - added support for env section to render to bound environment file
  - added support for container features like gpu
+ - list defaults to showing modules/tags one per line, unless --short used
  - container url does not render in docs (0.0.23)
  - addition of tcl modules, removal of un-needed database (0.0.22)
  - first update of all containers, and bugfix to pull (0.0.21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/master) (0.0.x)
  - adding namespaces to make module install, show, inspect easier (0.0.24)
+ - added support for env section to render to bound environment file
  - container url does not render in docs (0.0.23)
  - addition of tcl modules, removal of un-needed database (0.0.22)
  - first update of all containers, and bugfix to pull (0.0.21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The versions coincide with releases on pip. Only major versions will be released
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/master) (0.0.x)
  - adding namespaces to make module install, show, inspect easier (0.0.24)
  - added support for env section to render to bound environment file
+ - added support for container features like gpu
  - container url does not render in docs (0.0.23)
  - addition of tcl modules, removal of un-needed database (0.0.22)
  - first update of all containers, and bugfix to pull (0.0.21)

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -1,0 +1,397 @@
+.. _getting_started-developer-guide:
+
+===============
+Developer Guide
+===============
+
+This developer guide includes more complex interactions like contributing
+registry entries and building containers. If you haven't read :ref:`getting_started-installation`
+you should do that first.
+
+
+Creating a Registry
+===================
+
+A registry consists of a database of local containers files, which are added
+to the module system as executables for your user base. This typically means that you are a
+linux administrator of your cluster, and shpc should be installed for you to use
+(but your users will not be interacting with it).
+
+The Registry Folder
+-------------------
+
+Although you likely will add custom containers, it's very likely that you
+want to provide a set of core containers that are fairly standard, like Python
+and other scientific packages. For this reason, Singularity Registry HPC
+comes with a registry folder, or a folder with different containers and versions
+that you can easily install. For example, here is a recipe for a Python 3.9.2 container
+that would be installed to your modules as we showed above:
+
+.. code-block:: yaml
+
+    docker: python
+    latest:
+      3.9.2: sha256:7d241b7a6c97ffc47c72664165de7c5892c99930fb59b362dd7d0c441addc5ed
+    tags:
+      3.9.2: sha256:7d241b7a6c97ffc47c72664165de7c5892c99930fb59b362dd7d0c441addc5ed
+      3.9.2-alpine: sha256:23e717dcd01e31caa4a8c6a6f2d5a222210f63085d87a903e024dd92cb9312fd
+    filter:
+    - 3.9.*
+    maintainer: '@vsoch'
+    url: https://hub.docker.com/_/python
+    aliases:
+      python: python
+
+And then you would install the module file and container as follows:
+
+.. code-block:: console
+
+    $ shpc install python:3.9.2
+
+But since latest is already 3.9.2, you could leave out the tag.
+
+.. code-block:: console
+
+    $ shpc install python/3.9.2
+
+
+And the module folder shown previously would be generated. Currently, we assume
+that any new install will re-pull the container (and remove a previous one).
+We will eventually update this to only re-generate if the hash is different.
+
+Contributing Registry Recipes
+-----------------------------
+
+If you want to add a new registry file, you are encouraged to contribute it here
+for others to use. You should:
+
+1. Add the recipe to the ``registry`` folder in its logical namespace, either a docker or GitHub uri
+2. The name of the recipe should be ``container.yaml``. You can use another recipe as a template, or see details in :ref:`getting_started-writing-registry-entries`
+3. You are encouraged to add tests and then test with ``shpc test``. See :ref:`getting_started-commands-test` for details about testing.
+4. You should generally choose smaller images (if possible) and define aliases (entrypoints) for the commands that you think would be useful.
+
+A shell entrypoint for the container will be generated automatically.
+When you open a pull request, if your branch prefix starts with ``recipe`` the PR
+will test your recipe automatically. If you forget, you can ask a maintainer to apply
+the ``container-recipe`` label and it will test accordingly.
+Once your recipe is added to the repository, the versions will be automatically
+updated with a nightly run. This means that you can pull the repository to get
+updated recipes, and then check for updates (the bot to do this is not developed yet):
+
+
+.. code-block:: console
+
+    $ shpc check python
+    ==> You have python 3.7 installed, but the latest is 3.8. Would you like to install?
+    yes/no : yes
+
+
+It's reasonable that you can store your recipes alongside these files, in the ``registry``
+folder. If you see a conflict and want to request allowing for a custom install path
+for recipes, please open an issue.
+
+
+.. _getting_started-writing-registry-entries:
+
+
+Writing Registry Entries
+========================
+
+An entry in the registry is a container.yaml file that lives in the ``registry``
+folder. You should create subfolders based on a package name. Multiple versions
+will be represented in the same file, and will install to the admin user's module
+folder with version subfolders. E.g., two registry entries, one for python
+(a single level name) and for tensorflow (a more nested name) would look like
+this:
+
+.. code-block:: console
+
+    registry/
+    ├── python
+    │       └── container.yaml
+    └── tensorflow
+        └── tensorflow
+            └── container.yaml
+
+
+And this is what gets installed to the modules folder, where each is kept in
+a separate directory based on version.
+
+.. code-block:: console
+
+    $ tree modules/
+    modules/
+    └── python
+        └── 3.9.2
+            ├── module.lua
+            └── python-3.9.2.sif
+
+    2 directories, 2 files
+
+So different versions could exist alongside one another.
+
+Registry Yaml Files
+===================
+
+Docker Hub
+----------
+
+The typical registry yaml file will reference a container from a registry,
+one or more versions, and a maintainer GitHub alias that can be pinged
+for any issues:
+
+
+.. code-block:: yaml
+
+    docker: python
+    latest:
+      3.9.2-slim: "sha256:85ed629e6ff79d0bf796339ea188c863048e9aedbf7f946171266671ee5c04ef"
+    tags:
+      3.9.2-slim: "sha256:85ed629e6ff79d0bf796339ea188c863048e9aedbf7f946171266671ee5c04ef"
+      3.9.2-alpine: "sha256:23e717dcd01e31caa4a8c6a6f2d5a222210f63085d87a903e024dd92cb9312fd"
+    filter:
+      - "3.9.*"
+    maintainer: "@vsoch"
+    url: https://hub.docker.com/_/python
+    aliases:
+      python: /usr/local/bin/python
+
+
+The above shows the simplest form of representing an alias, where each is
+a key (python) and value (/usr/local/bin/python) set.
+
+
+Environment Variables
+---------------------
+
+
+Finally, each recipe has an optional section for environment variables. For
+example, the container ``vanessa/salad`` shows definition of one environment
+variable:
+
+.. code-block:: yaml
+
+    docker: vanessa/salad
+    url: https://hub.docker.com/r/vanessa/salad
+    maintainer: '@vsoch'
+    description: A container all about fork and spoon puns.
+    latest:
+      latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
+    tags:
+      latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
+    aliases:
+      salad: /code/salad
+    env:
+      maintainer: vsoch
+
+And then during build, this variable is written to a ``99-shpc.sh`` file that
+is mounted into the countainer. For the above, the following will be written:
+
+.. code-block:: console
+
+    export maintainer=vsoch
+
+If a recipe does not have environment variables in the container.yaml, you have
+two options for adding a variable after install. For a more permanent solution,
+you can update the container.yaml file and install again. The container won't
+be re-pulled, but the environment file will be re-generated. If you want to 
+manually add them to the container, each module folder will have an environment
+file added regardless of having this section or not, so you can export them there.
+When you shell, exec, or run the container (all but inspect) you should be able
+to see your environment variables:
+
+.. code-block:: console
+
+    $ echo $maintainer
+    vsoch
+
+
+Singularity Deploy
+------------------
+
+Using `Singularity Deploy <https://github.com/singularityhub/singularity-deploy>`_
+you can easily deploy a container as a GitHub release! See the repository for
+details. The registry entry should look like:
+
+.. code-block:: yaml
+
+    gh: singularityhub/singularity-deploy
+    latest:
+      salad: "0.0.1"
+    tags:
+      salad: "0.0.1"
+    maintainer: "@vsoch"
+    url: https://github.com/singularityhub/singularity-deploy
+    aliases:
+      salad: /code/salad
+
+Where ``gh`` corresponds to the GitHub repository, the tags are the
+extensions of your Singularity recipes in the root, and the "versions"
+(e.g., 0.0.1) are the release numbers. There are examples in the registry
+(as shown above) for details.
+
+
+Choosing Containers to Contribute
+---------------------------------
+
+How should you choose container bases to contribute? You might consider using
+smaller images, when possible (take advantage of multi-stage builds) and
+for aliases, make sure (if possible) that you use full paths. If there is a
+directive that you need for creating the module file that isn't there, please
+open an issue so it can be added. Finally, if you don't have time to contribute directly, suggesting an idea via an issue or Slack to a maintainer (@vsoch).
+
+
+Registry Yaml Fields
+====================
+
+Fields include:
+
+.. list-table:: Title
+   :widths: 25 65 10
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Required
+   * - docker
+     - A Docker uri, which should include the registry but not tag
+     - true
+   * - tags
+     - A list of available tags
+     - true
+   * - latest
+     - The latest tag, along with the digest that will be updated by a bot in the repository (e.g., tag: digest)
+     - true
+   * - maintainer
+     - The GitHub alias of a maintainer to ping in case of trouble
+     - true
+   * - filter
+     - A list of patterns to use for adding new tags. If not defined, all are added 
+     - false
+   * - aliases
+     - Named entrypoints for container (dict)
+     - false
+   * - url
+     - Documentation or other url for the container uri
+     - false
+   * - description
+     - Additional information for the registry entry
+     - false
+
+Other supported (but not yet developed) fields could include different unique
+resource identifiers to pull/obtain other kinds of containers. For this
+current version, since we are assuming HPC and Singularity, we will typically
+pull a Docker unique resource identifier with singularity, e.g.,:
+
+
+.. code-block:: console
+
+    $ singularity pull docker://python:3.9.2
+
+
+Updating Registry Yaml Files
+============================
+
+We will be developing a GitHub action that automatically parses new versions
+for a container, and then updates the registry packages. The algorithm we will
+use is the following:
+
+ - If docker, retrieve all tags for the image
+ - Update tags:
+   - if one or more filters ("filter") are defined, add new tags that match
+   - otherwise, add all new tags
+ - If latest is defined and a version string can be parsed, update latest
+ - For each of latest and tags, add new version information
+
+
+.. _getting_started-development:
+
+Development or Testing
+======================
+
+If you first want to test singularity-hpc (shpc) with an LMOD installed in 
+a container, a ``Dockerfile`` is provided for LMOD, and ``Dockerfile.tcl``
+for tcl modules. The assumption is that
+you have a module system installed on your cluster or in the container. If not, you
+can find instructions `here for lmod <https://lmod.readthedocs.io/en/latest/030_installing.html>`_
+or `here for tcl <https://modules.readthedocs.io/en/latest/INSTALL.html>`_.
+
+
+.. code-block:: console
+    
+    $ docker build -t singularity-hpc .
+
+If you are developing the library and need the module software, you can easily bind your
+code as follows:
+
+
+.. code-block:: console
+
+    $ docker run -it --rm -v $PWD/:/code singularity-hpc
+
+Once you are in the container, you can direct the module software to use your module files:
+
+.. code-block:: console
+
+    $ module use /code/modules
+
+Then you can use spider to see the modules:
+
+.. code-block:: console
+
+    # module spider python
+
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------
+      python/3.9.2: python/3.9.2/module
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+        This module can be loaded directly: module load python/3.9.2/module
+    ```
+
+
+or ask for help directly!
+
+.. code-block:: console
+
+    # module help python/3.9.2-slim
+
+    ----------------------------------------------------- Module Specific Help for "python/3.9.2-slim/module" ------------------------------------------------------
+    This module is a singularity container wrapper for python v3.9.2-slim
+
+
+    Container:
+
+     - /home/vanessa/Desktop/Code/singularity-hpc/modules/python/3.9.2-slim/python-3.9.2-slim-sha256:85ed629e6ff79d0bf796339ea188c863048e9aedbf7f946171266671ee5c04ef.sif
+
+    Commands include:
+
+     - python-run:
+           singularity run <container>
+     - python-shell:
+           singularity shell -s /bin/bash <container>
+     - python-exec:
+           singularity exec -s /bin/bash <container> "$@"
+     - python-inspect-runscript:
+           singularity inspect -r <container>
+     - python-inspect-deffile:
+           singularity inspect -d <container>
+
+     - python:
+           singularity exec <container> /usr/local/bin/python"
+
+
+    For each of the above, you can export:
+
+     - SINGULARITY_OPTS: to define custom options for singularity (e.g., --debug)
+     - SINGULARITY_COMMAND_OPTS: to define custom options for the command (e.g., -b)
+
+
+Note that you typically can't run or execute containers within another container, but 
+you can interact with the module system. Also notice that for every container, we expose easy
+commands to shell, run, exec, and inspect. The custom commands (e.g., Python) are then provided below that.
+
+Make sure to write to files outside of the container so you don't muck with permissions.
+Since we are using module use, this means that you can create module files as a user
+or an admin - it all comes down to who has permission to write to the modules
+folder, and of course use it. Note that I have not tested this on an HPC system
+but plan to shortly.

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -16,4 +16,5 @@ If you have any questions or issues, please `let us know <https://github.com/sin
 
    installation
    user-guide
+   developer-guide
    use-cases

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -73,7 +73,7 @@ You'll next want to configure and create your registry, discussed next in
  variables in the config:
  
 
-.. code-black:: console
+.. code-block:: console
  
 
     $ shpc config set registry:/<DIR>

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -481,11 +481,39 @@ List
 ----
 
 Once a module is installed, you can use list to show installed modules (and versions).
+The default list will flatten out module names and tags into a single list
+to make it easy to copy paste:
 
 .. code-block:: console
 
     $ shpc list
-    python: 3.9.2-alpine, 3.9.2-slim
+        biocontainers/samtools:v1.9-4-deb_cv1
+                        python:3.9.2-alpine
+                        python:3.9.5-alpine
+                        python:3.9.2-slim
+                      dinosaur:fork
+                 vanessa/salad:latest
+                         salad:latest
+      ghcr.io/autamus/prodigal:latest
+      ghcr.io/autamus/samtools:latest
+        ghcr.io/autamus/clingo:5.5.0
+
+
+However, if you want a shorter version that shows multiple tags alongside
+each unique module name, just add ``--short``:
+
+.. code-block:: console
+
+    $ shpc list --short
+
+        biocontainers/samtools: v1.9-4-deb_cv1
+                        python: 3.9.5-alpine, 3.9.2-alpine, 3.9.2-slim
+                      dinosaur: fork
+                 vanessa/salad: latest
+                         salad: latest
+      ghcr.io/autamus/prodigal: latest
+      ghcr.io/autamus/samtools: latest
+        ghcr.io/autamus/clingo: 5.5.0
 
 
 Inspect

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -209,6 +209,9 @@ A summary table of variables is included below, and then further discussed in de
    * - namespace
      - Set a default module namespace that you want to install from.
      - null
+   * - environment_file
+     - The name of the environment file to generate and bind to the container.
+     - 99-shpc.sh
 
 
 
@@ -721,6 +724,7 @@ bypython (per what is available on your system). To start a shell:
 
     $ shpc shell
 
+
 or with a specific interpreter:
 
 .. code-block:: console
@@ -937,6 +941,51 @@ Since we want to add the "--nv" flag, we add it as an option. Keep in mind
 that since we have a list, you technically could provide duplicate commands.
 However, the list is parsed into a dictionary, so only unique values are 
 enforced. If you accidentally have a repeated value, a warning will be printed.
+
+Environment Variables
+---------------------
+
+
+Finally, each recipe has an optional section for environment variables. For
+example, the container ``vanessa/salad`` shows definition of one environment
+variable:
+
+.. code-block:: yaml
+
+    docker: vanessa/salad
+    url: https://hub.docker.com/r/vanessa/salad
+    maintainer: '@vsoch'
+    description: A container all about fork and spoon puns.
+    latest:
+      latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
+    tags:
+      latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
+    aliases:
+      salad: /code/salad
+    env:
+      maintainer: vsoch
+
+And then during build, this variable is written to a ``99-shpc.sh`` file that
+is mounted into the countainer. For the above, the following will be written:
+
+.. code-block:: console
+
+    export maintainer=vsoch
+
+If a recipe does not have environment variables in the container.yaml, you have
+two options for adding a variable after install. For a more permanent solution,
+you can update the container.yaml file and install again. The container won't
+be re-pulled, but the environment file will be re-generated. If you want to 
+manually add them to the container, each module folder will have an environment
+file added regardless of having this section or not, so you can export them there.
+When you shell, exec, or run the container (all but inspect) you should be able
+to see your environment variables:
+
+.. code-block:: console
+
+    $ echo $maintainer
+    vsoch
+
 
 Singularity Deploy
 ------------------

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -18,6 +18,17 @@ the name) it's created to be modular, meaning that if another container technolo
 is wanted, it can be added. The module name would still be appropriate, as
 singularity does imply a single entity that is "one library to rule them all!"
 
+What is a registry?
+===================
+
+A registry consists of a database of local containers configuration files, ``container.yaml``
+files organized in the root of the shpc install in the ``registry`` folder. The namespace
+is organized by Docker unique resources identifiers. When you install an identifier
+as we saw above, the container binaries and customized module files are added to 
+the ``module_dir`` defined in your settings, which defaults to ``modules`` in the
+root of the install. You should see the :ref:`getting_started-developer-guide`
+for more information about contributing containers to this registry.
+
 
 Really Quick Start
 ==================
@@ -40,7 +51,8 @@ Quick Start
 ===========
 
 After  :ref:`getting_started-installation`, and let's say shpc is installed 
-at ``~/singularity-hpc`` you can install a container:
+at ``~/singularity-hpc`` you can edit your settings in ``settings.yaml`` and
+then install a container:
 
 .. code-block:: console
 
@@ -75,90 +87,8 @@ For more detailed tutorials, you should continue reading,
 and see :ref:`getting_started-use-cases`. Also see the :ref:`getting_started-commands-config` for how to update configuration values with ``shpc config``.
 
 
-Creating a Registry
-===================
-
-A registry consists of a database of local containers files, which are added
-to the module system as executables for your user base. This typically means that you are a
-linux administrator of your cluster, and shpc should be installed for you to use
-(but your users will not be interacting with it).
-
-The Registry Folder
--------------------
-
-Although you likely will add custom containers, it's very likely that you
-want to provide a set of core containers that are fairly standard, like Python
-and other scientific packages. For this reason, Singularity Registry HPC
-comes with a registry folder, or a folder with different containers and versions
-that you can easily install. For example, here is a recipe for a Python 3.9.2 container
-that would be installed to your modules as we showed above:
-
-.. code-block:: yaml
-
-    docker: python
-    latest:
-      3.9.2: sha256:7d241b7a6c97ffc47c72664165de7c5892c99930fb59b362dd7d0c441addc5ed
-    tags:
-      3.9.2: sha256:7d241b7a6c97ffc47c72664165de7c5892c99930fb59b362dd7d0c441addc5ed
-      3.9.2-alpine: sha256:23e717dcd01e31caa4a8c6a6f2d5a222210f63085d87a903e024dd92cb9312fd
-    filter:
-    - 3.9.*
-    maintainer: '@vsoch'
-    url: https://hub.docker.com/_/python
-    aliases:
-      python: python
-
-And then you would install the module file and container as follows:
-
-.. code-block:: console
-
-    $ shpc install python:3.9.2
-
-But since latest is already 3.9.2, you could leave out the tag.
-
-.. code-block:: console
-
-    $ shpc install python/3.9.2
-
-
-And the module folder shown previously would be generated. Currently, we assume
-that any new install will re-pull the container (and remove a previous one).
-We will eventually update this to only re-generate if the hash is different.
-
-Contributing Registry Recipes
------------------------------
-
-If you want to add a new registry file, you are encouraged to contribute it here
-for others to use. You should:
-
-1. Add the recipe to the ``registry`` folder in its logical namespace, either a docker or GitHub uri
-2. The name of the recipe should be ``container.yaml``. You can use another recipe as a template, or see details in :ref:`getting_started-writing-registry-entries`
-3. You are encouraged to add tests and then test with ``shpc test``. See :ref:`getting_started-commands-test` for details about testing.
-4. You should generally choose smaller images (if possible) and define aliases (entrypoints) for the commands that you think would be useful.
-
-A shell entrypoint for the container will be generated automatically.
-When you open a pull request, if your branch prefix starts with ``recipe`` the PR
-will test your recipe automatically. If you forget, you can ask a maintainer to apply
-the ``container-recipe`` label and it will test accordingly.
-Once your recipe is added to the repository, the versions will be automatically
-updated with a nightly run. This means that you can pull the repository to get
-updated recipes, and then check for updates (the bot to do this is not developed yet):
-
-
-.. code-block:: console
-
-    $ shpc check python
-    ==> You have python 3.7 installed, but the latest is 3.8. Would you like to install?
-    yes/no : yes
-
-
-It's reasonable that you can store your recipes alongside these files, in the ``registry``
-folder. If you see a conflict and want to request allowing for a custom install path
-for recipes, please open an issue.
-
-
 Setup
------
+=====
 
 Setup includes, after installation, editing any configuration values to
 customize your install. The defaults are likely suitable for most.
@@ -212,11 +142,54 @@ A summary table of variables is included below, and then further discussed in de
    * - environment_file
      - The name of the environment file to generate and bind to the container.
      - 99-shpc.sh
+   * - features
+     - A key, value paired set of features to add to the container (see table below)
+     - All features default to null
 
 
+These settings will be discussed in more detail in the following sections.
+
+Features
+--------
+
+Features are key value pairs that you can set to a determined set of values
+to influence how your module files are written. For example, if you set the
+gpu feature to "nvidia" in your settings file:
+
+.. code-block:: yaml
+
+    container_features:
+      gpu: "nvidia"
+
+
+and a container.yaml recipe has a gpu:true container feature to say "this container
+supports gpu":
+
+.. code-block:: yaml
+
+    features:
+      gpu: true
+     
+Given that you are installing a module for a Singularity container, the ``--nv``
+option will be added. Currently, the following features are supported:
+
+
+.. list-table:: Title
+   :widths: 10 40 25 25
+   :header-rows: 1
+
+   * - Name
+     - Description
+     - Default
+     - Options
+   * - gpu
+     - If the container technology supports it, add flags to indicate using gpu.
+     - null
+     - nvidia, amd, null
+     
 
 Modules Folder
-^^^^^^^^^^^^^^
+--------------
 
 The first thing you want to do is configure your module location, if you want it different
 from the default. The path can be absolute or relative to ``$install_dir`` (the shpc
@@ -229,10 +202,10 @@ your install:
 .. code-block:: console
 
     # an absolute path
-    $ shpc config module_base:/opt/lmod/modules
+    $ shpc config set module_base:/opt/lmod/modules
 
     # or a path relative to a variable location remember to escape the "$"
-    $ shpc config module_base:\$root_dir/modules
+    $ shpc config set module_base:\$root_dir/modules
 
 
 This directory will be the base where lua files are added, and container are stored.
@@ -253,7 +226,7 @@ a unique namespace.
 
 
 Container Images Folder
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 If you don't want your container images (sif files) to live alongside your
 module files, then you should define the ``container_base`` to be something
@@ -262,7 +235,7 @@ non-null (a path that exists). For example:
 .. code-block:: console
 
     $ mkdir -p /tmp/containers
-    $ shpc config container_base:/tmp/containers
+    $ shpc config set container_base:/tmp/containers
 
 
 The same hierarchy will be preserved as to not put all containers in the same
@@ -270,7 +243,7 @@ directory.
 
 
 Registry
-^^^^^^^^
+--------
 
 The registry folder in the root of the repository, but you can change it to
 be a custom one with the config variable ``registry``
@@ -279,20 +252,21 @@ be a custom one with the config variable ``registry``
 .. code-block:: console
 
     # change to your own registry of container yaml configs
-    $ shpc config registry:/opt/lmod/registry
+    $ shpc config set registry:/opt/lmod/registry
 
 
 
 Prefixes
-^^^^^^^^
+--------
 
 If you want your modules to have an alias prefix, you can
 set ``module_exc_prefix`` (an alias prefix). If you want your modules
 to have a directory prefix, simply create the directory and then update
 the ``module_base`` path.
 
+
 Module Software
----------------
+===============
 
 The default module software is currently LMOD, and there is also support for tcl. If you
 are interested in adding another module type, please `open an issue <https://github.com/singularityhub/singularity-hpc>`_ and
@@ -309,13 +283,13 @@ or you can set the global variable to what you want to use (it defaults to lmod)
 
 .. code-block:: console
 
-    $ shpc config module_sys:tcl
+    $ shpc config set module_sys:tcl
 
 
 The command line argument, if provided, always over-rides the default.
 
 Container Technology
---------------------
+====================
 
 The default container technology to pull and then provide to users is Singularity,
 which makes sense because we can add executables to the path that are Singularity containers.
@@ -323,8 +297,8 @@ If you would like support for a different container technology, please also
 `open an issue <https://github.com/singularityhub/singularity-hpc>`_ and
 provide description and links to what you have in mind.
 
-
 .. _getting_started-commands:
+
 
 Commands
 ========
@@ -564,25 +538,6 @@ Or to get the entire metadata entry dumped as json to the terminal:
 .. _getting_started-commands-test:
 
 
-Shell
------
-
-If you want a quick way to shell into an installed module's container
-(perhaps to look around or debug without the module software being available) you can use
-``shell``. For example:
-
-.. code-block:: console
-
-    shpc shell vanessa/salad/latest
-    Singularity> /code/salad fork
-
-     My life purpose: I cut butter.  
-    
-                       ________  .====
-                      [________>< :===
-                                 '==== 
-
-
 
 Test
 ----
@@ -716,8 +671,26 @@ can also be used in a registry entry.
 Shell
 -----
 
-You can also interact with your registry interactively, and the easiest
-way to do that is to use the shell. It defaults to ipython, and then python and
+If you want a quick way to shell into an installed module's container
+(perhaps to look around or debug without the module software being available) you can use
+``shell``. For example:
+
+.. code-block:: console
+
+    shpc shell vanessa/salad/latest
+    Singularity> /code/salad fork
+
+     My life purpose: I cut butter.  
+    
+                       ________  .====
+                      [________>< :===
+                                 '==== 
+
+
+
+If you want to interact with the shpc Python client directly, you can
+do shell without a module identifier. This will give you a python terminal,
+which defaults to ipython, and then python and
 bypython (per what is available on your system). To start a shell:
 
 .. code-block:: console
@@ -743,6 +716,7 @@ And then you can interact with the client, which will be loaded.
     python
 
     client.install('python')
+
 
 
 Show
@@ -846,333 +820,3 @@ If you select a higher level module directory or there is no sif, you'll see:
 We could update this command to allow for listing all sif files within a top level
 module folder (for different versions). Please open an issue if this would be useful for
 you.
-
-
-.. _getting_started-writing-registry-entries:
-
-
-Writing Registry Entries
-========================
-
-An entry in the registry is a container.yaml file that lives in the ``registry``
-folder. You should create subfolders based on a package name. Multiple versions
-will be represented in the same file, and will install to the admin user's module
-folder with version subfolders. E.g., two registry entries, one for python
-(a single level name) and for tensorflow (a more nested name) would look like
-this:
-
-.. code-block:: console
-
-    registry/
-    ├── python
-    │       └── container.yaml
-    └── tensorflow
-        └── tensorflow
-            └── container.yaml
-
-
-And this is what gets installed to the modules folder, where each is kept in
-a separate directory based on version.
-
-.. code-block:: console
-
-    $ tree modules/
-    modules/
-    └── python
-        └── 3.9.2
-            ├── module.lua
-            └── python-3.9.2.sif
-
-    2 directories, 2 files
-
-So different versions could exist alongside one another.
-
-Registry Yaml Files
-===================
-
-Docker Hub
-----------
-
-The typical registry yaml file will reference a container from a registry,
-one or more versions, and a maintainer GitHub alias that can be pinged
-for any issues:
-
-
-.. code-block:: yaml
-
-    docker: python
-    latest:
-      3.9.2-slim: "sha256:85ed629e6ff79d0bf796339ea188c863048e9aedbf7f946171266671ee5c04ef"
-    tags:
-      3.9.2-slim: "sha256:85ed629e6ff79d0bf796339ea188c863048e9aedbf7f946171266671ee5c04ef"
-      3.9.2-alpine: "sha256:23e717dcd01e31caa4a8c6a6f2d5a222210f63085d87a903e024dd92cb9312fd"
-    filter:
-      - "3.9.*"
-    maintainer: "@vsoch"
-    url: https://hub.docker.com/_/python
-    aliases:
-      python: /usr/local/bin/python
-
-
-The above shows the simplest form of representing an alias, where each is
-a key (python) and value (/usr/local/bin/python) set. As an alternative,
-for aliases with more complex settings (e.g., additional arguments to provide
-to exec) you can describe these same attributes as a list. Here is an example
-for tensorflow:
-
-.. code-block:: yaml
-
-    docker: tensorflow/tensorflow
-    latest:
-      2.2.2: sha256:e2cde2bb70055511521d995cba58a28561089dfc443895fd5c66e65bbf33bfc0
-    tags:
-      2.2.2: sha256:e2cde2bb70055511521d995cba58a28561089dfc443895fd5c66e65bbf33bfc0
-    filter:
-    - 2.*
-    maintainer: '@vsoch'
-    url: https://hub.docker.com/r/tensorflow/tensorflow
-    aliases:
-    - name: python
-      command: python
-      options: "--nv"
-
-
-Since we want to add the "--nv" flag, we add it as an option. Keep in mind
-that since we have a list, you technically could provide duplicate commands.
-However, the list is parsed into a dictionary, so only unique values are 
-enforced. If you accidentally have a repeated value, a warning will be printed.
-
-Environment Variables
----------------------
-
-
-Finally, each recipe has an optional section for environment variables. For
-example, the container ``vanessa/salad`` shows definition of one environment
-variable:
-
-.. code-block:: yaml
-
-    docker: vanessa/salad
-    url: https://hub.docker.com/r/vanessa/salad
-    maintainer: '@vsoch'
-    description: A container all about fork and spoon puns.
-    latest:
-      latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
-    tags:
-      latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
-    aliases:
-      salad: /code/salad
-    env:
-      maintainer: vsoch
-
-And then during build, this variable is written to a ``99-shpc.sh`` file that
-is mounted into the countainer. For the above, the following will be written:
-
-.. code-block:: console
-
-    export maintainer=vsoch
-
-If a recipe does not have environment variables in the container.yaml, you have
-two options for adding a variable after install. For a more permanent solution,
-you can update the container.yaml file and install again. The container won't
-be re-pulled, but the environment file will be re-generated. If you want to 
-manually add them to the container, each module folder will have an environment
-file added regardless of having this section or not, so you can export them there.
-When you shell, exec, or run the container (all but inspect) you should be able
-to see your environment variables:
-
-.. code-block:: console
-
-    $ echo $maintainer
-    vsoch
-
-
-Singularity Deploy
-------------------
-
-Using `Singularity Deploy <https://github.com/singularityhub/singularity-deploy>`_
-you can easily deploy a container as a GitHub release! See the repository for
-details. The registry entry should look like:
-
-.. code-block:: yaml
-
-    gh: singularityhub/singularity-deploy
-    latest:
-      salad: "0.0.1"
-    tags:
-      salad: "0.0.1"
-    maintainer: "@vsoch"
-    url: https://github.com/singularityhub/singularity-deploy
-    aliases:
-      salad: /code/salad
-
-Where ``gh`` corresponds to the GitHub repository, the tags are the
-extensions of your Singularity recipes in the root, and the "versions"
-(e.g., 0.0.1) are the release numbers. There are examples in the registry
-(as shown above) for details.
-
-
-Choosing Containers to Contribute
----------------------------------
-
-How should you choose container bases to contribute? You might consider using
-smaller images, when possible (take advantage of multi-stage builds) and
-for aliases, make sure (if possible) that you use full paths. If there is a
-directive that you need for creating the module file that isn't there, please
-open an issue so it can be added. Finally, if you don't have time to contribute directly, suggesting an idea via an issue or Slack to a maintainer (@vsoch).
-
-
-Registry Yaml Fields
-====================
-
-Fields include:
-
-.. list-table:: Title
-   :widths: 25 65 10
-   :header-rows: 1
-
-   * - Name
-     - Description
-     - Required
-   * - docker
-     - A Docker uri, which should include the registry but not tag
-     - true
-   * - tags
-     - A list of available tags
-     - true
-   * - latest
-     - The latest tag, along with the digest that will be updated by a bot in the repository (e.g., tag: digest)
-     - true
-   * - maintainer
-     - The GitHub alias of a maintainer to ping in case of trouble
-     - true
-   * - filter
-     - A list of patterns to use for adding new tags. If not defined, all are added 
-     - false
-   * - aliases
-     - Named entrypoints for container (dict)
-     - false
-   * - url
-     - Documentation or other url for the container uri
-     - false
-   * - description
-     - Additional information for the registry entry
-     - false
-
-Other supported (but not yet developed) fields could include different unique
-resource identifiers to pull/obtain other kinds of containers. For this
-current version, since we are assuming HPC and Singularity, we will typically
-pull a Docker unique resource identifier with singularity, e.g.,:
-
-
-.. code-block:: console
-
-    $ singularity pull docker://python:3.9.2
-
-
-Updating Registry Yaml Files
-============================
-
-We will be developing a GitHub action that automatically parses new versions
-for a container, and then updates the registry packages. The algorithm we will
-use is the following:
-
- - If docker, retrieve all tags for the image
- - Update tags:
-   - if one or more filters ("filter") are defined, add new tags that match
-   - otherwise, add all new tags
- - If latest is defined and a version string can be parsed, update latest
- - For each of latest and tags, add new version information
-
-
-.. _getting_started-development:
-
-Development or Testing
-======================
-
-If you first want to test singularity-hpc (shpc) with an LMOD installed in 
-a container, a ``Dockerfile`` is provided for LMOD, and ``Dockerfile.tcl``
-for tcl modules. The assumption is that
-you have a module system installed on your cluster or in the container. If not, you
-can find instructions `here <https://lmod.readthedocs.io/en/latest/030_installing.html>`_
-for lmod, or `here _<https://modules.readthedocs.io/en/latest/INSTALL.html>`_ for tcl.
-
-
-.. code-block:: console
-    
-    $ docker build -t singularity-hpc .
-
-If you are developing the library and need the module software, you can easily bind your
-code as follows:
-
-
-.. code-block:: console
-
-    $ docker run -it --rm -v $PWD/:/code singularity-hpc
-
-Once you are in the container, you can direct the module software to use your module files:
-
-.. code-block:: console
-
-    $ module use /code/modules
-
-Then you can use spider to see the modules:
-
-.. code-block:: console
-
-    # module spider python
-
-    --------------------------------------------------------------------------------------------------------------------------------------------------------------
-      python/3.9.2: python/3.9.2/module
-    --------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-        This module can be loaded directly: module load python/3.9.2/module
-    ```
-
-
-or ask for help directly!
-
-.. code-block:: console
-
-    # module help python/3.9.2-slim
-
-    ----------------------------------------------------- Module Specific Help for "python/3.9.2-slim/module" ------------------------------------------------------
-    This module is a singularity container wrapper for python v3.9.2-slim
-
-
-    Container:
-
-     - /home/vanessa/Desktop/Code/singularity-hpc/modules/python/3.9.2-slim/python-3.9.2-slim-sha256:85ed629e6ff79d0bf796339ea188c863048e9aedbf7f946171266671ee5c04ef.sif
-
-    Commands include:
-
-     - python-run:
-           singularity run <container>
-     - python-shell:
-           singularity shell -s /bin/bash <container>
-     - python-exec:
-           singularity exec -s /bin/bash <container> "$@"
-     - python-inspect-runscript:
-           singularity inspect -r <container>
-     - python-inspect-deffile:
-           singularity inspect -d <container>
-
-     - python:
-           singularity exec <container> /usr/local/bin/python"
-
-
-    For each of the above, you can export:
-
-     - SINGULARITY_OPTS: to define custom options for singularity (e.g., --debug)
-     - SINGULARITY_COMMAND_OPTS: to define custom options for the command (e.g., -b)
-
-
-Note that you typically can't run or execute containers within another container, but 
-you can interact with the module system. Also notice that for every container, we expose easy
-commands to shell, run, exec, and inspect. The custom commands (e.g., Python) are then provided below that.
-
-Make sure to write to files outside of the container so you don't muck with permissions.
-Since we are using module use, this means that you can create module files as a user
-or an admin - it all comes down to who has permission to write to the modules
-folder, and of course use it. Note that I have not tested this on an HPC system
-but plan to shortly.

--- a/registry/nvcr.io/hpc/autodock/container.yaml
+++ b/registry/nvcr.io/hpc/autodock/container.yaml
@@ -12,7 +12,7 @@ tags:
   2020.06-arm64: sha256:2d881faf0b20866826a2f0ebbd87ed9791b64222489814901a090e5ed1aa3252
 filter:
 - ^((?!arm).)*$
+features:
+  gpu: true
 aliases:
-- name: autodock-gpu
-  command: /opt/AutoDock-GPU/bin/autodock_gpu_128wi
-  options: --nv
+  autodock: /opt/AutoDock-GPU/bin/autodock_gpu_128wi

--- a/registry/nvcr.io/hpc/gromacs/container.yaml
+++ b/registry/nvcr.io/hpc/gromacs/container.yaml
@@ -11,7 +11,7 @@ tags:
   "2021": sha256:aa095dcdb175e10132a5862204bf91e6f374f72ba9f2360d9ff5c45ae67785fd
 filter:
 - ^((?!arm).)*$
+features:
+  gpu: true
 aliases:
-- name: python
-  command: /usr/bin/python
-  options: --nv
+  python: /usr/bin/python

--- a/registry/nvcr.io/nvidia/caffe/container.yaml
+++ b/registry/nvcr.io/nvidia/caffe/container.yaml
@@ -9,6 +9,6 @@ latest:
 tags:
   20.03-py3: sha256:c6fb6d8309be4c43ccdc7dd19dde73d186404df3627f660866178eff507e22c7
 aliases:
-- name: python
-  command: /usr/bin/python
-  options: --nv
+  python: /usr/bin/python
+features:
+  gpu: true

--- a/registry/nvcr.io/nvidia/digits/container.yaml
+++ b/registry/nvcr.io/nvidia/digits/container.yaml
@@ -13,6 +13,6 @@ tags:
 filter:
 - 21*
 aliases:
-- name: python
-  command: /usr/bin/python
-  options: --nv
+  python: /usr/bin/python
+features:
+  gpu: true

--- a/registry/tensorflow/tensorflow/container.yaml
+++ b/registry/tensorflow/tensorflow/container.yaml
@@ -10,7 +10,7 @@ tags:
   2.5.0rc0-gpu-jupyter: sha256:9808e04142b09482bb6b3d1738430ae7472a214dd38e086d41e481b376fa9abd
 filter:
 - 2.*
+features:
+  gpu: true
 aliases:
-- name: python
-  command: /usr/local/bin/python
-  options: --nv
+  python: /usr/local/bin/python

--- a/registry/vanessa/salad/container.yaml
+++ b/registry/vanessa/salad/container.yaml
@@ -8,5 +8,7 @@ tags:
   latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
 aliases:
   salad: /code/salad
+features:
+  gpu: true
 env:
   maintainer: vsoch

--- a/registry/vanessa/salad/container.yaml
+++ b/registry/vanessa/salad/container.yaml
@@ -8,3 +8,5 @@ tags:
   latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
 aliases:
   salad: /code/salad
+env:
+  maintainer: vsoch

--- a/registry/vanessa/salad/container.yaml
+++ b/registry/vanessa/salad/container.yaml
@@ -8,7 +8,5 @@ tags:
   latest: sha256:e8302da47e3200915c1d3a9406d9446f04da7244e4995b7135afd2b79d4f63db
 aliases:
   salad: /code/salad
-features:
-  gpu: true
 env:
   maintainer: vsoch

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -202,9 +202,9 @@ def get_parser():
         command.add_argument(
             "--container_tech",
             dest="container_tech",
-            help="container technology to use (defaults to singularity)",
+            help="container technology to use to override settings.yaml",
             choices=["singularity"],
-            default="singularity",
+            default=None,
         )
 
     namespace = subparsers.add_parser(

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -84,6 +84,13 @@ def get_parser():
         "--names-only", help="omit versions", default=False, action="store_true"
     )
 
+    listing.add_argument(
+        "--short",
+        help="multiple tags per line for shorter length output.",
+        default=False,
+        action="store_true",
+    )
+
     # List local containers and collections
     inspect = subparsers.add_parser(
         "inspect", help="inspect an installed module image."

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -102,7 +102,10 @@ def get_parser():
 
     # Add a container direcly
     add = subparsers.add_parser("add", help="add an image to local storage")
-    add.add_argument("paths", help="full path to container image file", nargs=2)
+    add.add_argument("sif_path", help="full path to container image file", nargs=1)
+    add.add_argument(
+        "module_id", help='desired identifier for module (e.g. "name/version")', nargs=1
+    )
 
     check = subparsers.add_parser("check", help="check if you have latest installed.")
     check.add_argument("module_name", help="module to check (module/version)")

--- a/shpc/client/add.py
+++ b/shpc/client/add.py
@@ -13,4 +13,4 @@ def main(args, parser, extra, subparser):
         module=args.module,
         container_tech=args.container_tech,
     )
-    cli.add(args.paths[0], args.paths[1])
+    cli.add(args.sif_path[0], args.module_id[0])

--- a/shpc/client/listing.py
+++ b/shpc/client/listing.py
@@ -14,4 +14,4 @@ def main(args, parser, extra, subparser):
         container_tech=args.container_tech,
     )
 
-    cli.list(args.pattern, args.names_only)
+    cli.list(args.pattern, args.names_only, short=args.short)

--- a/shpc/main/__init__.py
+++ b/shpc/main/__init__.py
@@ -19,12 +19,12 @@ def get_client(quiet=False, **kwargs):
     quiet: if True, suppress most output about the client (e.g. speak)
 
     """
-    # The name of the module and container technology to use
+    # The name of the module
     module = kwargs.get("module")
-    container = kwargs.get("container_tech")
 
-    # Load user settings to add to client
+    # Load user settings to add to client, and container technology
     settings = Settings(kwargs.get("settings_file"))
+    container = kwargs.get("container_tech") or settings.container_tech
 
     # Use the user provided module OR the default
     module = module or settings.get("module_sys", "lmod")

--- a/shpc/main/client.py
+++ b/shpc/main/client.py
@@ -76,7 +76,7 @@ class Client:
     def __str__(self):
         return "[shpc-client]"
 
-    def install(self, name, tag=None):
+    def install(self, name, tag=None, **kwargs):
         """
         Install must be implemented by the subclass (e.g., lmod)
         """

--- a/shpc/main/container.py
+++ b/shpc/main/container.py
@@ -214,6 +214,12 @@ class ContainerConfig:
         """
         jsonschema.validate(instance=self._config, schema=schemas.containerConfig)
 
+    def get_envars(self):
+        """
+        Return loaded environment variables.
+        """
+        return dict(self.env) if self.env else {}
+
     def get_aliases(self):
         """
         Return a consistently formatted list of aliases

--- a/shpc/main/container.py
+++ b/shpc/main/container.py
@@ -17,12 +17,61 @@ import jsonschema
 import sys
 
 
-class SingularityContainer:
+class ContainerTechnology:
+    """
+    A base class for a container technology
+    """
+
+    # The module technology adds extensions here
+    modulefile = "module"
+
+    # By default, no extra features
+    features = {}
+
+    def get_features(self, config_features, settings_features, extra=None):
+        """
+        Get feature values based onsettings and features defined for the container.
+        """
+        config_features = config_features or {}
+        extra = extra or []
+
+        # If extra features are added at runtime, they are set to true
+        for extra_feature in extra:
+            if extra_feature not in config_features:
+                config_features[extra_feature.lower()] = True
+
+        features = {}
+
+        # The config features (defined by the container) determine what we add
+        for key, value in config_features.items():
+
+            # If the container technology has the feature and is defined in settings
+            if key in self.features and key in settings_features:
+
+                # And if the settings feature is known to the container technology
+                if settings_features[key] in self.features[key]:
+
+                    # Add the feature to be given to the container!
+                    features[key] = self.features[key][settings_features[key]]
+
+        return features
+
+    def __str__(self):
+        return str(self.__class__.__name__)
+
+
+class SingularityContainer(ContainerTechnology):
     """
     A Singularity container controller.
 
     All container controllers should have the same general interface.
     """
+
+    # The module technology adds extensions here
+    templatefile = "singularity"
+
+    # Singularity container features
+    features = {"gpu": {"nvidia": "--nv", "amd": "--rocm"}}
 
     def __init__(self):
         try:

--- a/shpc/main/lmod/__init__.py
+++ b/shpc/main/lmod/__init__.py
@@ -11,5 +11,4 @@ class Client(ModuleBase):
         An Lmod client generates an lmod recipe for install
         """
         super(Client, self).__init__(**kwargs)
-        self.modulefile = "module.lua"
-        self.templatefile = "template.lua"
+        self.module_extension = "lua"

--- a/shpc/main/lmod/singularity.lua
+++ b/shpc/main/lmod/singularity.lua
@@ -16,19 +16,19 @@ Container:
 Commands include:
 
  - {{ prefix }}{{ flatname }}-run:
-       singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
+       singularity run {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
  - {{ prefix }}{{ flatname }}-shell:
-       singularity shell -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
+       singularity shell -s {{ singularity_shell }} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
  - {{ prefix }}{{ flatname }}-exec:
-       singularity exec -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> "$@"
+       singularity exec -s {{ singularity_shell }} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> "$@"
  - {{ prefix }}{{ flatname }}-inspect-runscript:
        singularity inspect -r <container>
  - {{ prefix }}{{ flatname }}-inspect-deffile:
        singularity inspect -d <container>
 
 {% if aliases %}{% for alias in aliases %} - {{ alias.name }}:
-       singularity exec {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}
-{% endfor %}{% else %} - {{ prefix }}{{ flatname }}: singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>{% endif %}
+       singularity exec {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}
+{% endfor %}{% else %} - {{ prefix }}{{ flatname }}: singularity run {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>{% endif %}
 
 For each of the above, you can export:
 
@@ -47,9 +47,9 @@ setenv("SINGULARITY_SHELL", "{{ singularity_shell }}")
 
 -- interactive shell to any container, plus exec for aliases
 local containerPath = '{{ container_sif }}'
-local shellCmd = "singularity ${SINGULARITY_OPTS} shell ${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath
-local execCmd = "singularity ${SINGULARITY_OPTS} exec ${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
-local runCmd = "singularity ${SINGULARITY_OPTS} run ${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath .. " ${ SINGULARITY_COMMAND_ARGS }"
+local shellCmd = "singularity ${SINGULARITY_OPTS} shell ${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath
+local execCmd = "singularity ${SINGULARITY_OPTS} exec ${SINGULARITY_COMMAND_OPTS} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
+local runCmd = "singularity ${SINGULARITY_OPTS} run ${SINGULARITY_COMMAND_OPTS} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath .. " ${ SINGULARITY_COMMAND_ARGS }"
 local inspectCmd = "singularity ${SINGULARITY_OPTS} inspect ${SINGULARITY_COMMAND_OPTS} " 
 
 -- set_shell_function takes bashStr and cshStr

--- a/shpc/main/lmod/template.lua
+++ b/shpc/main/lmod/template.lua
@@ -16,19 +16,19 @@ Container:
 Commands include:
 
  - {{ prefix }}{{ flatname }}-run:
-       singularity run {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
+       singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
  - {{ prefix }}{{ flatname }}-shell:
-       singularity shell -s {{ singularity_shell }} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
+       singularity shell -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>
  - {{ prefix }}{{ flatname }}-exec:
-       singularity exec -s {{ singularity_shell }} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> "$@"
+       singularity exec -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> "$@"
  - {{ prefix }}{{ flatname }}-inspect-runscript:
        singularity inspect -r <container>
  - {{ prefix }}{{ flatname }}-inspect-deffile:
        singularity inspect -d <container>
 
 {% if aliases %}{% for alias in aliases %} - {{ alias.name }}:
-       singularity exec {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}
-{% endfor %}{% else %} - {{ prefix }}{{ flatname }}: singularity run {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>{% endif %}
+       singularity exec {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}
+{% endfor %}{% else %} - {{ prefix }}{{ flatname }}: singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>{% endif %}
 
 For each of the above, you can export:
 
@@ -47,9 +47,9 @@ setenv("SINGULARITY_SHELL", "{{ singularity_shell }}")
 
 -- interactive shell to any container, plus exec for aliases
 local containerPath = '{{ container_sif }}'
-local shellCmd = "singularity ${SINGULARITY_OPTS} shell ${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath
-local execCmd = "singularity ${SINGULARITY_OPTS} exec ${SINGULARITY_COMMAND_OPTS} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
-local runCmd = "singularity ${SINGULARITY_OPTS} run ${SINGULARITY_COMMAND_OPTS} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath .. " ${ SINGULARITY_COMMAND_ARGS }"
+local shellCmd = "singularity ${SINGULARITY_OPTS} shell ${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath
+local execCmd = "singularity ${SINGULARITY_OPTS} exec ${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
+local runCmd = "singularity ${SINGULARITY_OPTS} run ${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} " .. containerPath .. " ${ SINGULARITY_COMMAND_ARGS }"
 local inspectCmd = "singularity ${SINGULARITY_OPTS} inspect ${SINGULARITY_COMMAND_OPTS} " 
 
 -- set_shell_function takes bashStr and cshStr

--- a/shpc/main/modules.py
+++ b/shpc/main/modules.py
@@ -187,12 +187,17 @@ class ModuleBase(BaseClient):
             logger.exit("Found more than one sif in module folder.")
         return sif[0]
 
-    def list(self, pattern=None, names_only=False, out=None):
+    def list(self, pattern=None, names_only=False, out=None, short=False):
         """
         List installed modules.
         """
         self._list_modules(
-            self.settings.module_base, self.modulefile, pattern, names_only, out
+            self.settings.module_base,
+            self.modulefile,
+            pattern,
+            names_only,
+            out,
+            short=short,
         )
 
     def docgen(self, module_name, out=None):
@@ -240,7 +245,9 @@ class ModuleBase(BaseClient):
         sif = self.get(module_name)
         return self._container.inspect(sif[0])
 
-    def _list_modules(self, base, filename, pattern=None, names_only=False, out=None):
+    def _list_modules(
+        self, base, filename, pattern=None, names_only=False, out=None, short=False
+    ):
         """A shared function to list modules or registry entries."""
         out = out or sys.stdout
         modules = self._get_module_lookup(base, filename, pattern)
@@ -253,8 +260,11 @@ class ModuleBase(BaseClient):
         for module_name, versions in modules.items():
             if names_only:
                 out.write("%s\n" % module_name)
-            else:
+            elif short:
                 out.write("%s: %s\n" % (module_name.rjust(30), ", ".join(versions)))
+            else:
+                for version in versions:
+                    out.write("%s:%s\n" % (module_name.rjust(30), version))
 
     def _get_module_lookup(self, base, filename, pattern=None):
         """A shared function to get a lookup of installed modules or registry entries"""

--- a/shpc/main/modules.py
+++ b/shpc/main/modules.py
@@ -157,6 +157,7 @@ class ModuleBase(BaseClient):
         dest = os.path.join(container_dir, "%s-sha256:%s.sif" % (name, digest))
         shutil.copyfile(sif, dest)
         self._install(module_dir, dest, name)
+        self._add_environment(module_dir, {})
         logger.info("Module %s was created." % (module_name))
 
     def get(self, module_name):

--- a/shpc/main/modules.py
+++ b/shpc/main/modules.py
@@ -247,7 +247,7 @@ class ModuleBase(BaseClient):
             logger.exit("%s does not exist." % self.container_base)
 
         sif = self.get(module_name)
-        return self._container.inspect(sif[0])
+        return self._container.inspect(sif)
 
     def _list_modules(
         self, base, filename, pattern=None, names_only=False, out=None, short=False

--- a/shpc/main/modules.py
+++ b/shpc/main/modules.py
@@ -71,6 +71,10 @@ class ModuleBase(BaseClient):
         """
         Use a custom container directory, otherwise default to module dir.
         """
+        # If the user provided a tag, tags are converted to folders
+        if ":" in name:
+            name = name.replace(":", os.sep)
+
         if not self.settings.container_base:
             return os.path.join(self.settings.module_base, name)
         return os.path.join(self.settings.container_base, name)

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -57,6 +57,7 @@ containerConfigProperties = {
         "type": "array",
         "items": {"type": "string"},
     },
+    "env": aliases,
     "aliases": {
         "oneOf": [
             aliases,

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -17,6 +17,25 @@ aliases = {
     },
 }
 
+
+# Features in container.yaml can be boolean or null, as they need to be
+# container technology agnostic
+features = {
+    "type": "object",
+    "patternProperties": {"\\w[\\w-]*": {"type": ["boolean", "null"]}},
+}
+
+# container features can be null or a known string
+container_features = {
+    "type": "object",
+    "properties": {
+        "gpu": {
+            "oneOf": [{"type": "null"}, {"type": "string", "enum": ["nvidia", "amd"]}]
+        }
+    },
+}
+
+
 # Or a list
 aliases_list = {
     "type": "array",
@@ -58,6 +77,7 @@ containerConfigProperties = {
         "items": {"type": "string"},
     },
     "env": aliases,
+    "features": features,
     "aliases": {
         "oneOf": [
             aliases,
@@ -91,8 +111,11 @@ settingsProperties = {
     "singularity_module": {"type": ["string", "null"]},
     "bindpaths": {"type": ["string", "null"]},
     "updated_at": {"type": "string"},
+    "environment_file": {"type": "string"},
+    "container_tech": {"type": "string", "enum": ["singularity"]},
     "singularity_shell": {"type": "string", "enum": ["/bin/bash", "/bin/sh"]},
     "module_sys": {"type": "string", "enum": ["lmod", "tcl", None]},
+    "container_features": container_features,
 }
 
 
@@ -105,8 +128,11 @@ settings = {
         "registry",
         "module_base",
         "singularity_module",
+        "environment_file",
+        "container_tech",
         "bindpaths",
         "singularity_shell",
+        "container_features",
     ],
     "properties": settingsProperties,
 }

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -76,15 +76,28 @@ class Settings:
         return self.get(key)
 
     def set(self, key, value):
+        """
+        Set a setting based on key and value. If the key has :, it's nested
+        """
         value = True if value == "true" else value
         value = False if value == "false" else value
-        self._settings[key] = value
+
+        # This is a reference to a dictionary (object) setting
+        if ":" in key:
+            key, subkey = key.split(":")
+            self._settings[key][subkey] = value
+        else:
+            self._settings[key] = value
 
     def _substitutions(self, value):
         """
         Given a value, make substitutions
         """
         if isinstance(value, bool) or not value:
+            return value
+
+        # Currently dicts only support boolean or null so we return as is
+        elif isinstance(value, dict):
             return value
 
         for rep, repvalue in defaults.reps.items():

--- a/shpc/main/tcl/__init__.py
+++ b/shpc/main/tcl/__init__.py
@@ -11,5 +11,4 @@ class Client(ModuleBase):
         An Lmod client generates an lmod recipe for install
         """
         super(Client, self).__init__(**kwargs)
-        self.modulefile = "module.tcl"
-        self.templatefile = "template.tcl"
+        self.module_extension = "tcl"

--- a/shpc/main/tcl/singularity.tcl
+++ b/shpc/main/tcl/singularity.tcl
@@ -14,19 +14,19 @@ proc ModulesHelp { } {
     puts stderr " - {{ container_sif }}"
     puts stderr "Commands include:"
     puts stderr " - {{ prefix }}{{ flatname }}-run:"
-    puts stderr "       singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
+    puts stderr "       singularity run {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
     puts stderr " - {{ prefix }}{{ flatname }}-shell:"
-    puts stderr "       singularity shell -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
+    puts stderr "       singularity shell -s {{ singularity_shell }} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
     puts stderr " - {{ prefix }}{{ flatname }}-exec:"
-    puts stderr "       singularity exec -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> \"$@\""
+    puts stderr "       singularity exec -s {{ singularity_shell }} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> \"$@\""
     puts stderr " - {{ prefix }}{{ flatname }}-inspect-runscript:"
     puts stderr "       singularity inspect -r <container>"
     puts stderr " - {{ prefix }}{{ flatname }}-inspect-deffile:"
     puts stderr "       singularity inspect -d <container>"
 
 {% if aliases %}{% for alias in aliases %}    puts stderr " - {{ alias.name }}:"
-    puts stderr "       singularity exec {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}"
-{% endfor %}{% else %}    puts stderr " - {{ prefix }}{{ flatname }}: singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>"{% endif %}
+    puts stderr "       singularity exec {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}"
+{% endfor %}{% else %}    puts stderr " - {{ prefix }}{{ flatname }}: singularity run {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>"{% endif %}
 
     puts stderr "For each of the above, you can export:"
 
@@ -58,9 +58,9 @@ conflict {{ name }}
 setenv SINGULARITY_SHELL {{ singularity_shell }}
 
 # interactive shell to any container, plus exec for aliases
-set shellCmd "singularity \${SINGULARITY_OPTS} shell \${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath}" 
-set execCmd "singularity \${SINGULARITY_OPTS} exec \${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
-set runCmd "singularity \${SINGULARITY_OPTS} run \${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath} \${SINGULARITY_COMMAND_ARGS}"
+set shellCmd "singularity \${SINGULARITY_OPTS} shell \${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath}" 
+set execCmd "singularity \${SINGULARITY_OPTS} exec \${SINGULARITY_COMMAND_OPTS} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
+set runCmd "singularity \${SINGULARITY_OPTS} run \${SINGULARITY_COMMAND_OPTS} {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath} \${SINGULARITY_COMMAND_ARGS}"
 set inspectCmd "singularity \${SINGULARITY_OPTS} inspect \${SINGULARITY_COMMAND_OPTS} " 
 
 # set_shell_function takes bashStr and cshStr

--- a/shpc/main/tcl/template.tcl
+++ b/shpc/main/tcl/template.tcl
@@ -14,19 +14,19 @@ proc ModulesHelp { } {
     puts stderr " - {{ container_sif }}"
     puts stderr "Commands include:"
     puts stderr " - {{ prefix }}{{ flatname }}-run:"
-    puts stderr "       singularity run {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
+    puts stderr "       singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
     puts stderr " - {{ prefix }}{{ flatname }}-shell:"
-    puts stderr "       singularity shell -s {{ singularity_shell }} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
+    puts stderr "       singularity shell -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container>"
     puts stderr " - {{ prefix }}{{ flatname }}-exec:"
-    puts stderr "       singularity exec -s {{ singularity_shell }} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> \"$@\""
+    puts stderr "       singularity exec -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}<container> \"$@\""
     puts stderr " - {{ prefix }}{{ flatname }}-inspect-runscript:"
     puts stderr "       singularity inspect -r <container>"
     puts stderr " - {{ prefix }}{{ flatname }}-inspect-deffile:"
     puts stderr "       singularity inspect -d <container>"
 
 {% if aliases %}{% for alias in aliases %}    puts stderr " - {{ alias.name }}:"
-    puts stderr "       singularity exec {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}"
-{% endfor %}{% else %}    puts stderr " - {{ prefix }}{{ flatname }}: singularity run {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>"{% endif %}
+    puts stderr "       singularity exec {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}"
+{% endfor %}{% else %}    puts stderr " - {{ prefix }}{{ flatname }}: singularity run {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>"{% endif %}
 
     puts stderr "For each of the above, you can export:"
 
@@ -58,9 +58,9 @@ conflict {{ name }}
 setenv SINGULARITY_SHELL {{ singularity_shell }}
 
 # interactive shell to any container, plus exec for aliases
-set shellCmd "singularity \${SINGULARITY_OPTS} shell \${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath}" 
-set execCmd "singularity \${SINGULARITY_OPTS} exec \${SINGULARITY_COMMAND_OPTS} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
-set runCmd "singularity \${SINGULARITY_OPTS} run \${SINGULARITY_COMMAND_OPTS} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath} \${SINGULARITY_COMMAND_ARGS}"
+set shellCmd "singularity \${SINGULARITY_OPTS} shell \${SINGULARITY_COMMAND_OPTS} -s {{ singularity_shell }} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath}" 
+set execCmd "singularity \${SINGULARITY_OPTS} exec \${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} "
+set runCmd "singularity \${SINGULARITY_OPTS} run \${SINGULARITY_COMMAND_OPTS} {% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %} ${containerPath} \${SINGULARITY_COMMAND_ARGS}"
 set inspectCmd "singularity \${SINGULARITY_OPTS} inspect \${SINGULARITY_COMMAND_OPTS} " 
 
 # set_shell_function takes bashStr and cshStr

--- a/shpc/main/templates.py
+++ b/shpc/main/templates.py
@@ -1,0 +1,11 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+
+environment_file = """#!/bin/sh
+
+# Add custom environment variables here with export
+{% for key, value in envars.items() %}export {{ key }}="{{ value }}"
+{% endfor %}
+"""

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -1,10 +1,14 @@
 # The Singularity HPC settings file holds basic information about the
-# module system to use, and where modules are stored.
+# module system to use, and where modules are stored. All settings are
+# currently specific to singularity, but can be extended to other technologies.
 
 # set a default module system
 # Currently only lmod is supported. To request an additional system, 
 # please open an issue https://github.com/singularityhub/singularity-hpc
 module_sys: lmod
+
+# set a default container technology (currently only singularity supported)
+container_tech: singularity
 
 # Registry Recipes (currently we support just one path)
 registry: $root_dir/registry
@@ -17,7 +21,7 @@ module_base: $root_dir/modules
 container_base:
 
 # if defined, add to lmod script to load this Singularity module first
-singularity_module:
+singularity_module: null
 
 # if set, prefix module alias names with prefix (another kind of namespacing)
 module_exc_prefix: ''
@@ -35,3 +39,7 @@ namespace: null
 # THe name of the environment file to bind to the container.
 # This determines order of load
 environment_file: "99-shpc.sh"
+
+# container features like gpu will modify generated recipes
+container_features:
+  gpu: null # one of null, amd, or nvidia

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -31,3 +31,7 @@ singularity_shell: /bin/bash
 # the module namespace you want to install from. E.g., if you have ghcr.io/autamus/clingo
 # and you set the namespace to ghcr.io/autamus, you can just do: shpc install clingo.
 namespace: null
+
+# THe name of the environment file to bind to the container.
+# This determines order of load
+environment_file: "99-shpc.sh"

--- a/shpc/tests/test_client.py
+++ b/shpc/tests/test_client.py
@@ -55,6 +55,8 @@ def test_install_get(tmp_path, module_sys, module_file):
     assert os.path.exists(module_dir)
     module_file = os.path.join(module_dir, module_file)
     assert os.path.exists(module_file)
+    env_file = os.path.join(module_dir, client.settings.environment_file)
+    assert os.path.exists(env_file)
 
     assert client.get("python/3.9.2-alpine")
 

--- a/shpc/tests/test_client.py
+++ b/shpc/tests/test_client.py
@@ -79,7 +79,7 @@ def test_features(tmp_path, module_sys, module_file):
     content = shpc.utils.read_file(module_file)
     assert "--nv" not in content
 
-    client.uninstall("python:3.9.2-alpine")
+    client.uninstall("python:3.9.2-alpine", force=True)
 
     # Now update settings
     client.settings.set("container_features:gpu", "nvidia")

--- a/shpc/tests/test_client.sh
+++ b/shpc/tests/test_client.sh
@@ -68,6 +68,7 @@ echo
 echo "#### Testing list "
 runTest 0 $output shpc --settings-file $settings list --help
 runTest 0 $output shpc --settings-file $settings list
+runTest 0 $output shpc --settings-file $settings list --short
 runTest 0 $output shpc --settings-file $settings list salad
 
 echo


### PR DESCRIPTION
This will address the following issues.

### Environment variables

#358 to add support for defining custom environment variables in the container. This means that any container.yaml can define an env section:

```
env:
   maintainer: vsoch
```
And then this is written to the self.settings.environment_file, which defaults to 99-shpc.sh (so it is sourced close to last). This file is automatically added to every install or "add" folder regardless of these variables or not, so an admin can easily add an environment variable to it. The admin can also update the container.yaml and "re-install" (if the container version has not changed  it won't be re-pulled). Then the environment file is bound to the container where it should be in order to be sourced, at /.singularity.d/env/99-shpc.sh.

### Add Help

The add help was not very good - the "paths" argument was duplicated because of using nargs=2. It is now updated to better reflect a sif_path and module_id. This will fix https://github.com/singularityhub/singularity-hpc/issues/369.

### Developer Documentation

I did a small re-organization of the docs - as I was writing new sections I realized that the user docs (e.g., setup, commands) were confounded with more developer docs (writing a container.yaml recipe). So I split them into two files, one for developer docs and one for the same user docs. It's at least a start to make the documentation better!

<a id="container-features"></a>
### Container Features

We now have the ability to define container features! That means that any container.yaml can define a features section. For example, here is how to say "this container supports gpu":

```yaml
features:
  gpu: true
```
And this is done in a general way because we want these recipes to eventually be usable by multiple container technologies (e.g., podman). Then for the settings.yaml file, there is a matching `container_features` section. And this is where the admin of the registry can decide how to set the features. Here is the default:

```yaml
container_features
  gpu: null
```
And then if the admin has nvidia gpus, they would do:
```yaml
container_features
  gpu: nvidia
```
This is also done a bit generally because it's up to the container technology to say "oh, features.gpu defined as nvidia means I should add the `--nv` flag here! This also means that the templates for the module files (originally template.lua and template.tcl) need to be container technology specific. So they are renamed to `singularity.tcl` and `singularity.lua` accordingly. In the future we could have, for example, `podman.lua`  and `podman.tcl`.

### shpc list

The listing now shows full container names and tags, without spaces or multiple tags per container. This is the default:

```bash
$ shpc list
        biocontainers/samtools:v1.9-4-deb_cv1
                        python:3.9.5-alpine
                        python:3.9.2-slim
                        python:3.9.2-alpine
                      dinosaur:fork
                 vanessa/salad:latest
                         salad:latest
      ghcr.io/autamus/prodigal:latest
      ghcr.io/autamus/samtools:latest
        ghcr.io/autamus/clingo:5.5.0
```

And to get back to the original shorter list with multiple tags per line, the user can add `--short`

```bash
$ shpc list --short
        biocontainers/samtools: v1.9-4-deb_cv1
                        python: 3.9.2-slim, 3.9.5-alpine, 3.9.2-alpine
                      dinosaur: fork
                 vanessa/salad: latest
                         salad: latest
      ghcr.io/autamus/prodigal: latest
      ghcr.io/autamus/samtools: latest
        ghcr.io/autamus/clingo: 5.5.0
```
This will close #360.

## Using Tag Notation

The user can now reference an installed container like

```
shpc check container:tag
```
instead of being required to use a /
```
shpc check container/tag
```
This will close #361 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>