### PR TITLE
Removing lmod_base and other unused defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - Removing un-used defaults and lmod_base (0.0.30)
  - Allow environment variables in settings (0.0.29)
    - User settings file creation and use with shpc config inituser
    - registry is now a list to support multiple registry locations

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -43,7 +43,7 @@ if you install to a system python, meaning either of these commands:
 
 You will need to put the registry files elsewhere (update the ``registry`` config argument to the path), as they will not be installed
 alongside the package. The same is the case for modules - if you install to system
-python it's recommended to define ``lmod_base`` as something else, unless you
+python it's recommended to define ``module_base`` as something else, unless you
 can write to your install location. Installing locally ensures that you
 can easily store your module files along with the install (the default until you
 change it). Installation of singularity-hpc adds an executable, `shpc` to your path.
@@ -80,13 +80,20 @@ You'll next want to configure and create your registry, discussed next in
  
 
     $ shpc config set registry:/<DIR>
-    $ shpc config set lmod_base:/<DIR> 
+    $ shpc config set module_base:/<DIR> 
     $ shpc config set container_base:/<DIR> 
 
 
+Also importantly, if you are using environment modules (Tcl) and not LMOD, you need
+to tell shpc about this (as it defaults to LMOD):
+
+.. code-block:: console
+
+    $ shpc config set module_sys:tcl
+
 You can also easily (manually) update any settings in the ``shpc/settings.yaml`` file. 
-Again, see the :ref:`getting-started` pages for next steps for setup and configuration,
-and interacting with your modules.
+Take a look at this file for other configuration settings, and see the :ref:`getting-started` 
+pages for next steps for setup and configuration, and interacting with your modules.
 
 .. warning::
 

--- a/docs/getting_started/use-cases.rst
+++ b/docs/getting_started/use-cases.rst
@@ -11,12 +11,12 @@ If you are a linux administrator, you likely want to clone the repository
 directly (or use a release when they are available). Then you can install modules
 for your users from the local ``registry`` folder, create your own module files
 (and contribute them to the repository if they are useful!) and update the
-``lmod_base`` to be where you install modules.
+``module_base`` to be where you install modules.
 
 .. code-block:: console
 
     # an absolute path
-    $ shpc config lmod_base:/opt/lmod/shpc
+    $ shpc config module_base:/opt/lmod/shpc
 
 
 If you pull or otherwise update the install of shpc, the module files will update

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -34,7 +34,17 @@ for more information about contributing containers to this registry.
 Really Quick Start
 ==================
 
-Once you have shpc installed, you can easily install, load, and use modules:
+Once you have shpc installed, make sure you tell shpc what your module software is
+(note that you only need to run this command if you aren't using Lmod, which is the
+default).
+
+.. code-block:: console
+
+    $ shpc config set module_sys:tcl
+    $ shpc config set module_sys:lmod  # default
+
+
+You can then easily install, load, and use modules:
 
 .. code-block:: console
 
@@ -44,25 +54,41 @@ Once you have shpc installed, you can easily install, load, and use modules:
 
 
 The above assumes that you've installed the software, and have already
-added the modules folder to be seen by your module software. This step is shown in detail
-in the next section.
+added the modules folder to be seen by your module software. If your module
+software doesn't see the module, remember that you need to have done:
+
+.. code-block:: console
+
+    $ module use ./modules
+
+
+We walk through these steps in more detail in the next section.
 
 
 Quick Start
 ===========
 
 After  :ref:`getting_started-installation`, and let's say shpc is installed 
-at ``~/singularity-hpc`` you can edit your settings in ``settings.yaml`` and
-then install a container:
+at ``~/singularity-hpc`` you can edit your settings in ``settings.yaml``.
+Importantly, make sure your shpc install is configured to use the right module
+software, which is typicall lmod or tcl. Here is how to change from the default 
+"lmod" to "tcl" and then back:
+
+.. code-block:: console
+
+    $ shpc config set module_sys:tcl
+    $ shpc config set module_sys:lmod # this is the default, which we change back to!
+
+
+Once you have the correct module software indicated, try installing a container:
 
 .. code-block:: console
 
     $ shpc install python
     
-Add the modules folder to your lmod (you can run this in a bash profile or
-manually, and note that if you want to use Environment Modules, you need to add
-``--module-sys tcl``).
-
+Make sure that the local ./modules folder can be seen by your module software
+(you can run this in a bash profile or manually, and note that if you want to 
+use Environment Modules, you need to add ``--module-sys tcl``).
 
 .. code-block:: console
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -89,7 +89,7 @@ the software automatically generates alias to inspect, run, shell, or inspect
 container metadata. E.g., here is the shell command:
 
 ```bash
-$ biocontainer-samtools-shell
+$ samtools-shell
 ```
 
 Another compelling example is using a notebook provided by Jupyter Stacks [@cook2017opinionated]. 

--- a/shpc/defaults.py
+++ b/shpc/defaults.py
@@ -5,7 +5,6 @@ __license__ = "MPL 2.0"
 import os
 import shpc.utils as utils
 
-# Replacements can currently be made for the database_file and lmod_base
 install_dir = utils.get_installdir()
 reps = {"$install_dir": install_dir, "$root_dir": os.path.dirname(install_dir)}
 
@@ -22,24 +21,3 @@ allowed_envars = ["container_base", "module_base", "registry"]
 
 # The GitHub repository with recipes
 github_url = "https://github.com/singularityhub/singularity-hpc"
-
-# Defaults should correspond to fields in settings.yml
-# Testing checks that we have a 1:1 match
-
-# Currently only lmod is supported. To request an additional system,
-# please open an issue https://github.com/singularityhub/singularity-hpc
-plugins_enabled = ["lmod"]
-
-# Registry folder with subfolders of recipes
-recipes = os.path.join(reps["$root_dir"], "registry")
-
-# Lmod settings
-
-# The install directory for modules. Defaults to the install directory/modules
-lmod_base = os.path.join(reps["$root_dir"], "modules")
-
-# disable keeping a sqlite database with metadata
-database_disable = False
-
-# default database file
-database_file = os.path.join(reps["$root_dir"], "shpc.db")

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -69,6 +69,14 @@ class SettingsBase:
         """
         if not self.settings_file or not os.path.exists(self.settings_file):
             logger.exit("Settings file not found.")
+
+        # Make sure editor exists first!
+        editor = shpc.utils.which(self.config_editor)
+        if editor["return_code"] != 0:
+            logger.exit(
+                "Editor '%s' not found! Update with shpc config set config_editor:<name>"
+                % self.config_editor
+            )
         shpc.utils.run_command([self.config_editor, self.settings_file], stream=True)
 
     def get_settings_file(self, settings_file=None):

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
The docs have some old variables that are no longer used, and there were some unused defaults as well. This PR will remove both and fix #421.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>