### PR TITLE
Fixing bug that envars need to be escaped for tcl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - Fixing bug with using variables in recipe options (0.0.31)
  - Removing un-used defaults and lmod_base (0.0.30)
  - Allow environment variables in settings (0.0.29)
    - User settings file creation and use with shpc config inituser

--- a/registry/jupyter/datascience-notebook/container.yaml
+++ b/registry/jupyter/datascience-notebook/container.yaml
@@ -10,4 +10,4 @@ tags:
 aliases:
 - name: run-notebook
   command: jupyter notebook --no-browser --port=$(shuf -i 2000-65000 -n 1) --ip 0.0.0.0
-  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local
+  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local --bind $(mktemp -d):/run/user

--- a/registry/jupyter/minimal-notebook/container.yaml
+++ b/registry/jupyter/minimal-notebook/container.yaml
@@ -10,4 +10,4 @@ tags:
 aliases:
 - name: run-notebook
   command: jupyter notebook --no-browser --port=$(shuf -i 2000-65000 -n 1) --ip 0.0.0.0
-  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local
+  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local --bind $(mktemp -d):/run/user

--- a/registry/jupyter/pyspark-notebook/container.yaml
+++ b/registry/jupyter/pyspark-notebook/container.yaml
@@ -10,4 +10,4 @@ tags:
 aliases:
 - name: run-notebook
   command: jupyter notebook --no-browser --port=$(shuf -i 2000-65000 -n 1) --ip 0.0.0.0
-  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local
+  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local --bind $(mktemp -d):/run/user

--- a/registry/jupyter/r-notebook/container.yaml
+++ b/registry/jupyter/r-notebook/container.yaml
@@ -10,4 +10,4 @@ tags:
 aliases:
 - name: run-notebook
   command: jupyter notebook --no-browser --port=$(shuf -i 2000-65000 -n 1) --ip 0.0.0.0
-  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local
+  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local --bind $(mktemp -d):/run/user

--- a/registry/jupyter/scipy-notebook/container.yaml
+++ b/registry/jupyter/scipy-notebook/container.yaml
@@ -10,4 +10,4 @@ tags:
 aliases:
 - name: run-notebook
   command: jupyter notebook --no-browser --port=$(shuf -i 2000-65000 -n 1) --ip 0.0.0.0
-  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local
+  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local --bind $(mktemp -d):/run/user

--- a/registry/jupyter/tensorflow-notebook/container.yaml
+++ b/registry/jupyter/tensorflow-notebook/container.yaml
@@ -12,4 +12,4 @@ filter:
 aliases:
 - name: run-notebook
   command: jupyter notebook --no-browser --port=$(shuf -i 2000-65000 -n 1) --ip 0.0.0.0
-  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local
+  options: --home ${HOME} --bind ${HOME}/.local:/home/joyvan/.local --bind $(mktemp -d):/run/user

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -23,7 +23,7 @@ proc ModulesHelp { } {
     puts stderr " - {|module_name|}-inspect:"
     puts stderr "       {{ command }} inspect <container>"
 {% if aliases %}{% for alias in aliases %}    puts stderr " - {{ alias.name }}:"
-    puts stderr "       {{ command }} run -i{% if tty %}t{% endif %} --rm -u `id -u`:`id -g` --entrypoint {{ alias.entrypoint }} {% if envfile %}--envfile  {{ module_dir }}/{{ envfile }} {% endif %}{% if bindpaths %}-v {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %} -v . -w . <container> {{ alias.args }}"
+    puts stderr "       {{ command }} run -i{% if tty %}t{% endif %} --rm -u `id -u`:`id -g` --entrypoint {{ alias.entrypoint | replace("$", "\$") }} {% if envfile %}--envfile  {{ module_dir }}/{{ envfile }} {% endif %}{% if bindpaths %}-v {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options | replace("$", "\$") }} {% endif %} -v . -w . <container> {{ alias.args | replace("$", "\$") }}"
 {% endfor %}{% endif %}
 
     puts stderr "For each of the above, you can export:"
@@ -68,7 +68,7 @@ set-alias {|module_name|}-shell "${shellCmd}"
 
 # exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}
-set-alias {{ alias.name }} "${execCmd} {% if alias.options %} {{ alias.options }} {% endif %} --entrypoint {{ alias.entrypoint }} ${containerPath} {{ alias.args }}"
+set-alias {{ alias.name }} "${execCmd} {% if alias.options %} {{ alias.options | replace("$", "\$") }} {% endif %} --entrypoint {{ alias.entrypoint | replace("$", "\$") }} ${containerPath} {{ alias.args | replace("$", "\$") }}"
 {% endfor %}{% endif %}
 
 # A customizable exec function

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -29,7 +29,7 @@ proc ModulesHelp { } {
     puts stderr "       singularity inspect -d <container>"
     puts stderr ""    
 {% if aliases %}{% for alias in aliases %}    puts stderr " - {{ alias.name }}:"
-    puts stderr "       singularity exec {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options }} {% endif %}<container> {{ alias.command }}"
+    puts stderr "       singularity exec {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }} {% endif %}{% if alias.options %}{{ alias.options | replace("$", "\$") }} {% endif %}<container> {{ alias.command | replace("$", "\$") }}"
 {% endfor %}{% else %}    puts stderr " - {|module_name|}: singularity run {% if features.gpu %}{{ features.gpu }} {% endif %}{% if envfile %}-B {{ module_dir }}/{{ envfile }}:/.singularity.d/env/{{ envfile }}{% endif %} {% if bindpaths %}-B {{ bindpaths }}{% endif %}<container>"{% endif %}
     puts stderr ""
     puts stderr "For each of the above, you can export:"
@@ -77,7 +77,7 @@ set-alias {|module_name|}-shell "${shellCmd}"
 
 # exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}
-set-alias {{ alias.name }} "${execCmd} {% if alias.options %} {{ alias.options }} {% endif %} ${containerPath} {{ alias.command }}"
+set-alias {{ alias.name }} "${execCmd} {% if alias.options %} {{ alias.options | replace("$", "\$") }} {% endif %} ${containerPath} {{ alias.command | replace("$", "\$") }}"
 {% endfor %}{% endif %}
 
 # A customizable exec function

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.30"
+__version__ = "0.0.31"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
Also updating recipes for jupyter containers to create a temporary directory to bind to /var/run.

@zbeekman I think this should fix both the errors you were running into!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>