### PR TITLE
.version file should be written at the top level of module folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - `.version` file should be written in top level of module folders [#450](https://github.com/singularityhub/singularity-hpc/issues/450) (0.0.35)
  - Tcl modules use shell functions for bash, to export to child shells (0.0.34)
    - fixed missing singularity -B flag for custom home feature
    - fixed singularity.tcl to always replace $ with \$ for custom home feature

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -327,8 +327,11 @@ you can add or remove entries via the config variable ``registry``
 .. code-block:: console
 
     # change to your own registry of container yaml configs
-    $ shpc config set registry:/opt/lmod/registry
+    $ shpc config add registry:/opt/lmod/registry
 
+
+# Note that "add" is used for lists of things (e.g., the registry config variable is a list)
+and "set" is used to set a key value pair.
 
 
 Module Names

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -174,6 +174,9 @@ variable replacement. A summary table of variables is included below, and then f
    * - updated_at
      - a timestamp to keep track of when you last saved
      - never
+   * - default_version
+     - A boolean to indicate generating a .version file (LMOD or lua modules only)
+     - true
    * - singularity_module
      - if defined, add to module script to load this Singularity module first
      - null

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -306,7 +306,7 @@ class ModuleBase(BaseClient):
         shpc.utils.mkdirp([module_dir, container_dir])
 
         # Add a .version file to indicate the level of versioning (not for tcl)
-        if self.module_extension != "tcl":
+        if self.module_extension != "tcl" and self.settings.default_version == True:
             version_dir = os.path.join(self.settings.module_base, uri)
             version_file = os.path.join(version_dir, ".version")
             if not os.path.exists(version_file):

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -11,6 +11,7 @@ from jinja2 import Template
 
 from datetime import datetime
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import sys
@@ -303,6 +304,12 @@ class ModuleBase(BaseClient):
         subfolder = os.path.join(uri, tag.name)
         container_dir = self.container.container_dir(subfolder)
         shpc.utils.mkdirp([module_dir, container_dir])
+
+        # Add a .version file to indicate the level of versioning
+        version_dir = os.path.join(self.settings.module_base, uri)
+        version_file = os.path.join(version_dir, ".version")
+        if not os.path.exists(version_file):
+            Path(version_file).touch()
 
         # For Singularity this is a path, podman is a uri. If None is returned
         # there was an error and we cleanup

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -305,11 +305,12 @@ class ModuleBase(BaseClient):
         container_dir = self.container.container_dir(subfolder)
         shpc.utils.mkdirp([module_dir, container_dir])
 
-        # Add a .version file to indicate the level of versioning
-        version_dir = os.path.join(self.settings.module_base, uri)
-        version_file = os.path.join(version_dir, ".version")
-        if not os.path.exists(version_file):
-            Path(version_file).touch()
+        # Add a .version file to indicate the level of versioning (not for tcl)
+        if self.module_extension != "tcl":
+            version_dir = os.path.join(self.settings.module_base, uri)
+            version_file = os.path.join(version_dir, ".version")
+            if not os.path.exists(version_file):
+                Path(version_file).touch()
 
         # For Singularity this is a path, podman is a uri. If None is returned
         # there was an error and we cleanup

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -122,6 +122,7 @@ settingsProperties = {
     "module_name": {"type": "string"},
     "config_editor": {"type": "string"},
     "environment_file": {"type": "string"},
+    "default_version": {"type": "boolean"},
     "enable_tty": {"type": "boolean"},
     "container_tech": {"type": "string", "enum": ["singularity", "podman", "docker"]},
     "singularity_shell": {"type": "string", "enum": shells},

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -26,6 +26,9 @@ module_base: $root_dir/modules
 # This is where you might add a prefix to your module names, if desired.
 module_name: '{{ tool }}'
 
+# Create a .version file for LMOD in the module folder
+default_version: true
+
 # store containers separately from module files
 container_base:
 

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.34"
+__version__ = "0.0.35"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
This small change will add a .version file to the top level of module folders on install to address #450.  I don't have a cluster to test this on easily, so @nlvw it would be greatly appreciated if you'd like to test! @eburgueno I also fixed the bug that you found in the docs to close #445,

Signed-off-by: vsoch <vsoch@users.noreply.github.com>