### PR TITLE
Add/function args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
  - `.version` file should be written in top level of module folders [#450](https://github.com/singularityhub/singularity-hpc/issues/450) (0.0.35)
+  - tcl module functions need `$@` to handle additional arguments
  - Tcl modules use shell functions for bash, to export to child shells (0.0.34)
    - fixed missing singularity -B flag for custom home feature
    - fixed singularity.tcl to always replace $ with \$ for custom home feature

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -70,7 +70,7 @@ set-alias {|module_name|}-shell "${shellCmd}"
 {% if aliases %}
 if { [ module-info shell bash ] } {
   if { [ module-info mode load ] } {
-{% for alias in aliases %}    puts stdout "function {{ alias.name }}() { ${execCmd} {% if alias.docker_options %} {{ alias.docker_options | replace("$", "\$") }} {% endif %} --entrypoint {{ alias.entrypoint | replace("$", "\$") }} ${containerPath} {{ alias.args | replace("$", "\$") }}; }; export -f {{ alias.name }};"
+{% for alias in aliases %}    puts stdout "function {{ alias.name }}() { ${execCmd} {% if alias.docker_options %} {{ alias.docker_options | replace("$", "\$") }} {% endif %} --entrypoint {{ alias.entrypoint | replace("$", "\$") }} ${containerPath} {{ alias.args | replace("$", "\$") }} \$@; }; export -f {{ alias.name }};"
 {% endfor %}
   }
   if { [ module-info mode remove ] } {

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -78,7 +78,7 @@ set-alias {|module_name|}-shell "${shellCmd}"
 {% if aliases %}
 if { [ module-info shell bash ] } {
   if { [ module-info mode load ] } {
-{% for alias in aliases %}    puts stdout "function {{ alias.name }}() { ${execCmd} {% if alias.singularity_options %} {{ alias.singularity_options | replace("$", "\$") }} {% endif %} ${containerPath} {{ alias.command | replace("$", "\$") }}; }; export -f {{ alias.name }};"
+{% for alias in aliases %}    puts stdout "function {{ alias.name }}() { ${execCmd} {% if alias.singularity_options %} {{ alias.singularity_options | replace("$", "\$") }} {% endif %} ${containerPath} {{ alias.command | replace("$", "\$") }} \$@; }; export -f {{ alias.name }};"
 {% endfor %}
   }
   if { [ module-info mode remove ] } {


### PR DESCRIPTION
Here is a fix to test #454. I'm also wondering if this is an issue with versioning? Perhaps a newer version would be able to accept these args - indeed Singularity is pretty seamless so I thought it would work as is (and if I remember we used to have these and possible removed them?)

ping @marcodelapierre and @xdelaruelle  who I think removed all of the argument passing in https://github.com/singularityhub/singularity-hpc/pull/388/files