### PR TITLE
Refactoring module files to be named by version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,10 @@ build_singularity: &install_singularity
 install_podman: &install_podman
   name: Install Podman
   command: |-
-    . /etc/os-release
-    sudo apt-get -qq -y install podman
- 
+    apt update
+    sudo apt upgrade
+    sudo apt install podman
+    
 install_dependencies: &install_dependencies
   name: install dependencies
   command: |-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,6 @@ install_podman: &install_podman
   name: Install Podman
   command: |-
     . /etc/os-release
-    echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
-    curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-    sudo apt-get update -qq
     sudo apt-get -qq -y install podman
  
 install_dependencies: &install_dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - Refactoring shpc to install module files with filenames as the name (0.1.0)
  - `.version` file should be written in top level of module folders [#450](https://github.com/singularityhub/singularity-hpc/issues/450) (0.0.35)
   - tcl module functions need `$@` to handle additional arguments
  - Tcl modules use shell functions for bash, to export to child shells (0.0.34)

--- a/shpc/main/container/base.py
+++ b/shpc/main/container/base.py
@@ -43,9 +43,6 @@ class ContainerTechnology:
     A base class for a container technology
     """
 
-    # The module technology adds extensions here
-    modulefile = "module"
-
     # By default, no extra features
     features = {}
 

--- a/shpc/main/container/singularity.py
+++ b/shpc/main/container/singularity.py
@@ -71,7 +71,7 @@ class SingularityContainer(ContainerTechnology):
             logger.exit("Found more than one sif in module folder.")
         return sif[0]
 
-    def add(self, sif, module_name, modulefile, template, **kwargs):
+    def add(self, sif, module_name, module_path, template, **kwargs):
         """
         Manually add a registry container.
         """
@@ -91,9 +91,9 @@ class SingularityContainer(ContainerTechnology):
                     )
 
         # The user can have a different container directory defined
+        module_dir = os.path.dirname(module_path)
         container_dir = self.container_dir(module_name)
-        module_path = os.path.join(container_dir, modulefile)
-        shpc.utils.mkdirp([container_dir])
+        shpc.utils.mkdirp([container_dir, module_dir])
 
         # Name the container appropriately
         name = module_name.replace("/", "-")
@@ -142,9 +142,11 @@ class SingularityContainer(ContainerTechnology):
         features = self.get_features(
             config_features, self.settings.container_features, features
         )
+        # The parent directory of the container might have other containers
+        container_dir = os.path.dirname(container_path)
 
         # Remove any previous containers
-        for older in glob("%s%s*.sif" % (module_path, os.sep)):
+        for older in glob("%s%s*.sif" % (container_dir, os.sep)):
             if older == container_path:
                 continue
             os.remove(older)

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.35"
+__version__ = "0.1.0"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
This is a fairly large change to reflect typical cluster organization of a modulefile by name. Likely we will need to add the circle tests back to ensure everything is working properly, and a bit of testing on different clusters

Signed-off-by: vsoch <vsoch@users.noreply.github.com>