### PR TITLE
Fix: parsing of config parameters for set/get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - Bug with setting a nested value (0.0.38)
  - Adding quotes around tcl descriptions (0.0.37)
  - fixing bug with container install (does not honor module directory) (0.0.36)
  - `.version` file should be written in top level of module folders [#450](https://github.com/singularityhub/singularity-hpc/issues/450) (0.0.35)

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc

--- a/shpc/client/add.py
+++ b/shpc/client/add.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/check.py
+++ b/shpc/client/check.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/config.py
+++ b/shpc/client/config.py
@@ -41,7 +41,8 @@ def main(args, parser, extra, subparser):
                     % param
                 )
                 continue
-            key, value = param.split(":", 1)
+            value, key = param[::-1].split(":", 1)
+            key, value = key[::-1], value[::-1]
             if command == "set":
                 cli.settings.set(key, value)
                 logger.info("Updated %s to be %s" % (key, value))

--- a/shpc/client/config.py
+++ b/shpc/client/config.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.defaults as defaults
@@ -41,8 +41,8 @@ def main(args, parser, extra, subparser):
                     % param
                 )
                 continue
-            value, key = param[::-1].split(":", 1)
-            key, value = key[::-1], value[::-1]
+
+            key, value = param.split(":", 1)
             if command == "set":
                 cli.settings.set(key, value)
                 logger.info("Updated %s to be %s" % (key, value))

--- a/shpc/client/docgen.py
+++ b/shpc/client/docgen.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/get.py
+++ b/shpc/client/get.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/inspect.py
+++ b/shpc/client/inspect.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/install.py
+++ b/shpc/client/install.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/listing.py
+++ b/shpc/client/listing.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/namespace.py
+++ b/shpc/client/namespace.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/pull.py
+++ b/shpc/client/pull.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.main.container as container

--- a/shpc/client/shell.py
+++ b/shpc/client/shell.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/show.py
+++ b/shpc/client/show.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/test.py
+++ b/shpc/client/test.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/uninstall.py
+++ b/shpc/client/uninstall.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/defaults.py
+++ b/shpc/defaults.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/logger.py
+++ b/shpc/logger.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import logging as _logging

--- a/shpc/main/__init__.py
+++ b/shpc/main/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/client.py
+++ b/shpc/main/client.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/__init__.py
+++ b/shpc/main/container/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/base.py
+++ b/shpc/main/container/base.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/docker.py
+++ b/shpc/main/container/docker.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/podman.py
+++ b/shpc/main/container/podman.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/singularity.py
+++ b/shpc/main/container/singularity.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from shpc.main.client import Client as BaseClient

--- a/shpc/main/modules/lmod.py
+++ b/shpc/main/modules/lmod.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from shpc.main.modules import ModuleBase

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from shpc.main.modules import ModuleBase

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -183,7 +183,7 @@ class SettingsBase:
             logger.exit("You cannot use 'set' for a list. Use add/remove instead.")
 
         # This is a reference to a dictionary (object) setting
-        if ":" in value:
+        if isinstance(value, str) and ":" in value:
             subkey, value = value.split(":")
             self._settings[key][subkey] = value
         else:

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 
@@ -183,8 +183,8 @@ class SettingsBase:
             logger.exit("You cannot use 'set' for a list. Use add/remove instead.")
 
         # This is a reference to a dictionary (object) setting
-        if ":" in key:
-            key, subkey = key.split(":")
+        if ":" in value:
+            subkey, value = value.split(":")
             self._settings[key][subkey] = value
         else:
             self._settings[key] = value

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -119,7 +119,7 @@ class SettingsBase:
             key, subkey = key.split(":")
             value = self._settings[key][subkey]
         else:
-            value = self._settings[key]
+            value = self._settings.get(key, default)
         value = self._substitutions(value)
         # If we allow environment substitution, do it
         if key in defaults.allowed_envars and value:

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -114,7 +114,12 @@ class SettingsBase:
         """
         Get a settings value, doing appropriate substitution and expansion.
         """
-        value = self._settings.get(key, default)
+        # This is a reference to a dictionary (object) setting
+        if ":" in key:
+            key, subkey = key.split(":")
+            value = self._settings[key][subkey]
+        else:
+            value = self._settings[key]
         value = self._substitutions(value)
         # If we allow environment substitution, do it
         if key in defaults.allowed_envars and value:

--- a/shpc/main/templates.py
+++ b/shpc/main/templates.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import re

--- a/shpc/tests/test_container.py
+++ b/shpc/tests/test_container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2021 Vanessa Sochat.
+# Copyright (C) 2021-2022 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/shpc/tests/test_container_config.py
+++ b/shpc/tests/test_container_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2021 Vanessa Sochat.
+# Copyright (C) 2021-2022 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/shpc/tests/test_settings.py
+++ b/shpc/tests/test_settings.py
@@ -37,6 +37,8 @@ def test_set_get(tmp_path):
     settings.set("container_features", "gpu:amd")
     assert settings.container_base == "/tmp/containers"
     assert settings.container_features["gpu"] == "amd"
+    assert settings.get("container_features:gpu") == "amd"
+    assert settings.get("container_features")["gpu"] == "amd"
 
 
 def test_add_remove(tmp_path):

--- a/shpc/tests/test_settings.py
+++ b/shpc/tests/test_settings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2021 Vanessa Sochat.
+# Copyright (C) 2021-2022 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
@@ -34,7 +34,9 @@ def test_set_get(tmp_path):
     settings = Settings(settings_file)
     assert not settings.container_base
     settings.set("container_base", "/tmp/containers")
+    settings.set("container_features", "gpu:amd")
     assert settings.container_base == "/tmp/containers"
+    assert settings.container_features["gpu"] == "amd"
 
 
 def test_add_remove(tmp_path):

--- a/shpc/tests/test_utils.py
+++ b/shpc/tests/test_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2021 Vanessa Sochat.
+# Copyright (C) 2021-2022 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/shpc/utils/fileio.py
+++ b/shpc/utils/fileio.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import hashlib

--- a/shpc/utils/terminal.py
+++ b/shpc/utils/terminal.py
@@ -1,45 +1,11 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 
 from shpc.logger import logger
 from subprocess import Popen, PIPE, STDOUT
 import os
-
-
-def get_singularity_version(singularity_version=None):
-    """get_singularity_version will determine the singularity version for a
-    build first, an environmental variable is looked at, followed by
-    using the system version.
-
-    Parameters
-    ==========
-    singularity_version: if not defined, look for in environment. If still
-    not find, try finding via executing --version to Singularity. Only return
-    None if not set in environment or installed.
-    """
-
-    if singularity_version is None:
-        singularity_version = os.environ.get("SINGULARITY_VERSION")
-
-    if singularity_version is None:
-        try:
-            cmd = ["singularity", "--version"]
-            output = run_command(cmd)
-
-            if isinstance(output["message"], bytes):
-                output["message"] = output["message"].decode("utf-8")
-            singularity_version = output["message"].strip("\n")
-            logger.info("Singularity %s being used." % singularity_version)
-
-        except:
-            singularity_version = None
-            logger.warning(
-                "Singularity version not found, so it's likely not installed."
-            )
-
-    return singularity_version
 
 
 def which(software=None, strip_newline=True):

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -1,8 +1,8 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.37"
+__version__ = "0.0.38"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
Issue: shpc was failing to set nested configuration parameters:
```
$ shpc config set container_features:gpu:amd
container_features:gpu:amd cannot be added to config: 'gpu:amd' is not of type 'object'
```

This was because the original parsing would result in the following, under the hood:
```
key = "container_features"
value = "gpu:amd"
```

This PR fixes this issue:

```
$ shpc config set container_features:gpu:amd
Updated container_features:gpu to be amd
```

Under the hood:
```
key = "container_features:gpu"
value = "amd"
```

And checking:
```
$ shpc config get container_features
container_features             ordereddict([('gpu', 'amd'), ('x11', None), ('home', None)])
$ shpc config get container_features:gpu
container_features:gpu         amd
```

Important NOTE: I am unsure about the change I made for the `get` method in the second commit. I got rid of a get call using a 2nd `default` argument. Unsure whether this can result in bad behaviours.