### PR TITLE
Ensuring that we always load defaults and then update with user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.scom/singularityhub/singularity-hpc/tree/master) (0.0.x)
+ - Central config should be read first (and updated with user config) (0.0.4)
  - Add support for oras pull for singularity (0.0.39)
  - Bug with setting a nested value (0.0.38)
  - Adding quotes around tcl descriptions (0.0.37)

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -135,7 +135,10 @@ take preference over this one as follows:
     $ shpc config userinit
 
 
-The defaults in either file are likely suitable for most. For any configuration value 
+When you create a user settings file (or provide a custom settings file one off to
+the client) the shpc default settings will be read first, and then updated by your file.
+We do this so that if the default file updates and your user settings is missing a variable,
+we still use the default. The defaults in either file are likely suitable for most. For any configuration value 
 that you might set, the following variables are available to you:
 
  - ``$install_dir``: the shpc folder

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -35,6 +35,7 @@ class SettingsBase:
         # Set an updated time, in case it's written back to file
         self._settings = {"updated_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")}
         self.settings_file = None
+        self.user_settings = None
 
     def __str__(self):
         return "[shpc-settings]"
@@ -81,15 +82,14 @@ class SettingsBase:
 
     def get_settings_file(self, settings_file=None):
         """
-        Get the preferred used settings file.
+        Get the preferred user settings file, set user settings if exists.
         """
         # Only consider user settings if the file exists!
-        user_settings = None
         if os.path.exists(defaults.user_settings_file):
-            user_settings = defaults.user_settings_file
+            self.user_settings = defaults.user_settings_file
 
         # First preference to command line, then user settings, then default
-        return settings_file or user_settings or defaults.default_settings_file
+        return settings_file or self.user_settings or defaults.default_settings_file
 
     def load(self, settings_file=None):
         """
@@ -106,9 +106,14 @@ class SettingsBase:
         yaml = YAML()
         yaml.preserve_quotes = True
 
-        # Store the original settings for update as we go
-        with open(self.settings_file, "r") as fd:
+        # Always load default settings first
+        with open(defaults.default_setting_file, "r") as fd:
             self._settings = yaml.load(fd.read())
+
+        # Update with user or custom settings if not equal to default
+        if self.settings_file != defaults.default_setting_file:
+            with open(self.settings_file, "r") as fd:
+                self._settings.update(yaml.load(fd.read()))
 
     def get(self, key, default=None):
         """

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.39"
+__version__ = "0.0.4"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
Right now, when shpc is updated with new config values and the user has a custom setting, you can trigger an error if a needed value is missing. to get around this, we should always load the default settings file first, and then override with custom settings given that the preferred settings are not == the default

Signed-off-by: vsoch <vsoch@users.noreply.github.com>