### PR TITLE
bugfix for conflict() in modulefile templates 4x

### DIFF
--- a/shpc/main/modules/templates/docker.lua
+++ b/shpc/main/modules/templates/docker.lua
@@ -54,7 +54,7 @@ local inspectCmd = "{{ command }} ${PODMAN_OPTS} inspect ${PODMAN_COMMAND_OPTS} 
 set_shell_function("{|module_name|}-shell", shellCmd,  shellCmd)
 
 -- conflict with modules with the same name
-conflict("{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict({% if name != tool %}"{{ name }}",{% endif %}"{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}

--- a/shpc/main/modules/templates/docker.lua
+++ b/shpc/main/modules/templates/docker.lua
@@ -38,7 +38,7 @@ For each of the above, you can export:
 setenv ("PODMAN_OPTS", "")
 setenv ("PODMAN_COMMAND_OPTS", "")
 
--- we probably don't need this
+-- we probably do not need this
 local MODULEPATH="{{ module_dir }}"
 
 -- interactive shell to any container, plus exec for aliases
@@ -54,7 +54,7 @@ local inspectCmd = "{{ command }} ${PODMAN_OPTS} inspect ${PODMAN_COMMAND_OPTS} 
 set_shell_function("{|module_name|}-shell", shellCmd,  shellCmd)
 
 -- conflict with modules with the same name
-conflict(myModuleName(){% if aliases %}{% for alias in aliases %}{% if alias.name != name %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict("{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}

--- a/shpc/main/modules/templates/docker.lua
+++ b/shpc/main/modules/templates/docker.lua
@@ -56,7 +56,7 @@ local inspectCmd = "{{ command }} ${PODMAN_OPTS} inspect ${PODMAN_COMMAND_OPTS} 
 set_shell_function("{|module_name|}-shell", shellCmd,  shellCmd)
 
 -- conflict with modules with the same name
-conflict({% if name != tool %}"{{ name }}",{% endif %}"{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict("{{ tool }}"{% if name != tool %},"{{ name }}"{% endif %}{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -55,8 +55,8 @@ set helpcommand "This module is a {{ docker }} container wrapper for {{ name }} 
 {% endfor %}{% endif %}
 
 # conflict with modules with the same alias name
-{% if name != tool %}conflict {{ name }}{% endif %}
 conflict {{ tool }}
+{% if name != tool %}conflict {{ name }}{% endif %}
 {% if aliases %}{% for alias in aliases %}{% if alias.name != tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}
 

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -51,6 +51,7 @@ set helpcommand "This module is a {{ docker }} container wrapper for {{ name }} 
 {% endfor %}{% endif %}
 
 # conflict with modules with the same alias name
+{% if name != tool %}conflict {{ name }}{% endif %}
 conflict {{ tool }}
 {% if aliases %}{% for alias in aliases %}{% if alias.name != tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -51,8 +51,8 @@ set helpcommand "This module is a {{ docker }} container wrapper for {{ name }} 
 {% endfor %}{% endif %}
 
 # conflict with modules with the same alias name
-conflict {{ name }}
-{% if aliases %}{% for alias in aliases %}{% if alias.name != name %}conflict {{ alias.name }}{% endif %}
+conflict {{ tool }}
+{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}
 
 # interactive shell to any container, plus exec for aliases

--- a/shpc/main/modules/templates/singularity.lua
+++ b/shpc/main/modules/templates/singularity.lua
@@ -38,7 +38,7 @@ For each of the above, you can export:
 
 {% if singularity_module %}load("{{ singularity_module }}"){% endif %}
 
--- we probably don't need this
+-- we probably do not need this
 local MODULEPATH="{{ module_dir }}"
 
 -- singularity environment variables to bind the paths and set shell
@@ -58,7 +58,7 @@ local inspectCmd = "singularity ${SINGULARITY_OPTS} inspect ${SINGULARITY_COMMAN
 set_shell_function("{|module_name|}-shell", shellCmd,  shellCmd)
 
 -- conflict with modules with the same name
-conflict(myModuleName(){% if aliases %}{% for alias in aliases %}{% if alias.name != name %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict("{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}

--- a/shpc/main/modules/templates/singularity.lua
+++ b/shpc/main/modules/templates/singularity.lua
@@ -59,7 +59,7 @@ local inspectCmd = "singularity ${SINGULARITY_OPTS} inspect ${SINGULARITY_COMMAN
 set_shell_function("{|module_name|}-shell", shellCmd,  shellCmd)
 
 -- conflict with modules with the same name
-conflict({% if name != tool %}"{{ name }}",{% endif %}"{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict("{{ tool }}"{% if name != tool %},"{{ name }}"{% endif %}{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}

--- a/shpc/main/modules/templates/singularity.lua
+++ b/shpc/main/modules/templates/singularity.lua
@@ -58,7 +58,7 @@ local inspectCmd = "singularity ${SINGULARITY_OPTS} inspect ${SINGULARITY_COMMAN
 set_shell_function("{|module_name|}-shell", shellCmd,  shellCmd)
 
 -- conflict with modules with the same name
-conflict("{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict({% if name != tool %}"{{ name }}",{% endif %}"{{ tool }}"{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- exec functions to provide "alias" to module commands
 {% if aliases %}{% for alias in aliases %}

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -57,6 +57,7 @@ set helpcommand "This module is a singularity container wrapper for {{ name }} v
 {% endfor %}{% endif %}
 
 # conflict with modules with the same alias name
+{% if name != tool %}conflict {{ name }}{% endif %}
 conflict {{ tool }}
 {% if aliases %}{% for alias in aliases %}{% if alias.name != tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -57,8 +57,8 @@ set helpcommand "This module is a singularity container wrapper for {{ name }} v
 {% endfor %}{% endif %}
 
 # conflict with modules with the same alias name
-conflict {{ name }}
-{% if aliases %}{% for alias in aliases %}{% if alias != name %}conflict {{ alias.name }}{% endif %}
+conflict {{ tool }}
+{% if aliases %}{% for alias in aliases %}{% if alias.name != tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}
 
 # singularity environment variables to bind the paths and set shell

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -61,8 +61,8 @@ set helpcommand "This module is a singularity container wrapper for {{ name }} v
 {% endfor %}{% endif %}
 
 # conflict with modules with the same alias name
-{% if name != tool %}conflict {{ name }}{% endif %}
 conflict {{ tool }}
+{% if name != tool %}conflict {{ name }}{% endif %}
 {% if aliases %}{% for alias in aliases %}{% if alias.name != tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}
 


### PR DESCRIPTION
Hi @vsoch ,

have a look at these edits, I think they improve the way conflicts for modules are declared in the modulefile templates.

Bottom line: therefore, the main conflict was with either myModuleName() or {{ name }}; I think a more appropriate one is a having both {{ name }} and {{ tool }}. Plus, the conditional for alias names (checked against {{ tool }} ).

Example for quay.io/biocontainers/fastqc:0.11.9--0
- BEFORE: either "quay.io/biocontainers/fastqc:0.11.9--0" or "quay.io/biocontainers/fastqc"
- NOW: both "quay.io/biocontainers/fastqc" and "fastqc"
    The latter is useful for conflicts with other, non SHPC, modules.