### PR TITLE
gitignore: bin/ and lib/ for dev purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+bin/
+lib/
 shpc.db
 singularity_hpc.egg-info/
 env


### PR DESCRIPTION
Silly one, just to ignore `bin/` and `lib/` , for when shpc is built in the repo for developer purposes