### PR TITLE
bugfix for singularity pull (repeated output) and wrapper scripts template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - fixing but with stream command repeating output (0.0.46)
  - Adding support for wrapper scripts for global and container.yaml (0.0.45)
  - Lua and tcl module file bug fixes for shell functions and aliases (0.0.44)
   - restoring -B for Singularity bindpaths over using envar

--- a/shpc/main/container/singularity.py
+++ b/shpc/main/container/singularity.py
@@ -297,7 +297,7 @@ class SingularityContainer(ContainerTechnology):
 
     def pull(self, uri, dest):
         """
-        Pull a container to a destination
+        g Pull a container to a destination
         """
         if re.search("^(docker|shub|https|oras)", uri):
             return self._pull_regular(uri, dest)
@@ -310,7 +310,12 @@ class SingularityContainer(ContainerTechnology):
         """
         pull_folder = os.path.dirname(dest)
         name = os.path.basename(dest)
-        return self.client.pull(uri, name=name, pull_folder=pull_folder)
+        image, lines = self.client.pull(
+            uri, name=name, pull_folder=pull_folder, stream=True
+        )
+        for line in lines:
+            print(line, end="")
+        return image
 
     def inspect(self, image):
         """

--- a/shpc/main/container/singularity.py
+++ b/shpc/main/container/singularity.py
@@ -297,7 +297,7 @@ class SingularityContainer(ContainerTechnology):
 
     def pull(self, uri, dest):
         """
-        g Pull a container to a destination
+        Pull a container to a destination
         """
         if re.search("^(docker|shub|https|oras)", uri):
             return self._pull_regular(uri, dest)

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -195,6 +195,10 @@ class SettingsBase:
         """
         if isinstance(value, str) and value.lower() in ["none", "null"]:
             return None
+
+        # Ensure we strip strings
+        if isinstance(value, str):
+            value = value.strip()
         return value
 
     def set(self, key, value):

--- a/shpc/main/wrappers/base.py
+++ b/shpc/main/wrappers/base.py
@@ -91,7 +91,7 @@ class WrapperScript:
         template_paths = [os.path.dirname(template_file), templates]
 
         # Do we have a custom template path directory?
-        if "templates" in self.settings.wrapper_scripts:
+        if self.settings.wrapper_scripts.get("templates"):
             path = self.settings.wrapper_scripts["templates"]
             if not os.path.exists(path):
                 logger.exit(

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -69,14 +69,14 @@ wrapper_scripts:
   podman: docker.sh
 
   # use for singularity aliases (set to null to disable)
-  singularity: singularity.sh 
+  singularity: singularity.sh
 
   # Add an extra custom template directory (searched first)
   templates: null
 
 # the module namespace you want to install from. E.g., if you have ghcr.io/autamus/clingo
 # and you set the namespace to ghcr.io/autamus, you can just do: shpc install clingo.
-namespace:
+namespace: null
 
 # THe name of the environment file to bind to the container.
 # This determines order of load

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.45"
+__version__ = "0.0.46"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"


### PR DESCRIPTION
This PR will fix:

- #505 : the "templates" variable under wrapper scripts needs to be referenced differently because it will trigger an error if null (possibly there are differences based on how the yaml is parsed?)
- #504 : this was just a change to an underlying dependency, spython, and without updating here it prints twice. Updating here to correctly use stream we not only print once, but we get the lines in real time! So overall a big improvement on both fronts!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>