### PR TITLE
bugfix: without this, create_symlink would only be called based on the CLI argument, not the .yml setting

### DIFF
--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -212,8 +212,6 @@ class ModuleBase(BaseClient):
         Given an install command, if --symblink is provided make sure we have
         a symlink_base defined in settings and the directory exists.
         """
-        # Global override to arg
-        symlink = self.settings.symlink_tree is True or symlink
 
         if not symlink:
             return
@@ -381,6 +379,8 @@ class ModuleBase(BaseClient):
         subfolder = os.path.join(uri, tag.name)
         container_dir = self.container.container_dir(subfolder)
 
+        # Global override to arg
+        symlink = self.settings.symlink_tree is True or symlink
         # Cut out early if symlink desired but no home
         self.check_symlink(module_dir, symlink)
         shpc.utils.mkdirp([module_dir, container_dir])


### PR DESCRIPTION
This solves the bug I had described in https://github.com/singularityhub/singularity-hpc/pull/502#pullrequestreview-902443327 . The global setting `symlink_tree` was ignored, and the only way to get the symlinks was the CLI option.

In the end, it's got nothing to do with `symlink-tree` vs `symlink_tree`.

`create_symlink` is controlled by a `if symlink` where `symlink` is the CLI option _only_. Only `check_symlink` merges it with the value from `shpc/settings.yml`. With this change, the merge is done a level up in `install` itself, and benefits both `create_symlink` and `if symlink`