### PR TITLE
Minor refactoring of `check_symlink`

### DIFF
--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -209,16 +209,12 @@ class ModuleBase(BaseClient):
 
     def check_symlink(self, module_dir, symlink=False):
         """
-        Given an install command, if --symblink is provided make sure we have
-        a symlink_base defined in settings and the directory exists.
+        Given an install command, if --symlink-tree is provided make
+        sure we don't already have this symlink in.
         """
         if not symlink:
             return
 
-        # Create the symlink base for the user if it does not exist
-        if symlink and not os.path.exists(self.settings.symlink_base):
-            utils.mkdirp([self.settings.symlink_base])
-       
         # Get the symlink path - does it exist?
         symlink_path = self.get_symlink_path(module_dir)
         if os.path.exists(symlink_path) and not utils.confirm_action('%s already exists, are you sure you want to overwrite?' % symlink_path):
@@ -380,7 +376,7 @@ class ModuleBase(BaseClient):
         # Global override to arg
         symlink = self.settings.symlink_tree is True or symlink
 
-        # Cut out early if symlink desired or already exists
+        # Cut out early if symlink desired and already exists
         self.check_symlink(module_dir, symlink)
         shpc.utils.mkdirp([module_dir, container_dir])
 

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -207,14 +207,11 @@ class ModuleBase(BaseClient):
             if not os.path.exists(version_file):
                 Path(version_file).touch()
 
-    def check_symlink(self, module_dir, symlink=False):
+    def check_symlink(self, module_dir):
         """
         Given an install command, if --symlink-tree is provided make
         sure we don't already have this symlink in.
         """
-        if not symlink:
-            return
-
         # Get the symlink path - does it exist?
         symlink_path = self.get_symlink_path(module_dir)
         if os.path.exists(symlink_path) and not utils.confirm_action('%s already exists, are you sure you want to overwrite?' % symlink_path):
@@ -376,8 +373,9 @@ class ModuleBase(BaseClient):
         # Global override to arg
         symlink = self.settings.symlink_tree is True or symlink
 
-        # Cut out early if symlink desired and already exists
-        self.check_symlink(module_dir, symlink)
+        if symlink:
+            # Cut out early if symlink desired and already exists
+            self.check_symlink(module_dir)
         shpc.utils.mkdirp([module_dir, container_dir])
 
         # Add a .version file to indicate the level of versioning (not for tcl)

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -210,7 +210,7 @@ class ModuleBase(BaseClient):
     def check_symlink(self, module_dir):
         """
         Given an install command, if --symlink-tree is provided make
-        sure we don't already have this symlink in.
+        sure we don't already have this symlink in the tree.
         """
         # Get the symlink path - does it exist?
         symlink_path = self.get_symlink_path(module_dir)


### PR DESCRIPTION
Hiya,

There are two changes in this pull-request.

The first two commits are a follow up of 10cf953d9c29b282781b0e50c10bd4b3ab7295ef. No need to call `mkdirp` for `symlink_base` since `mkdirp` is anyway called in `create_symlink` to create the parent directory. Then I slightly refactor `check_symlink` to give it a similar interface to `create_symlink`, i.e.: both are only called if the user wants symlinks, and neither need to check the symlink parameter.

The last commit is about stripping `module.tcl` from being shown by `module avail` in the symlinks tree. This is done by making the symlinks point at the `module.tcl` files directly, rather than their enclosing directories. It makes the symlink tree much shorter and nicer to use.
To achieve that, I had to change the module templates to hardcode the path to the modules, because otherwise it couldn't find the `bin/` of the wrapper scripts.

Example trees:
```
containers/
├── golang
│   └── 1.18-rc
│       └── golang-1.18-rc-sha256:c9be2380bfdc0f4da95e1635e914dbd596bc73b618cdf16894a631eb58945156.sif
└── quay.io
    └── biocontainers
        ├── bwa
        │   └── 0.7.17--h7132678_9
        │       └── quay.io-biocontainers-bwa-0.7.17--h7132678_9-sha256:07822e4293a8c59755b295c448b9541db6c9bdbfdedb010bdbdcc1e1e935370f.sif
        ├── bwa-mem2
        │   └── 2.2.1--hd03093a_2
        │       └── quay.io-biocontainers-bwa-mem2-2.2.1--hd03093a_2-sha256:df046077d0771d622d2889039050a995a71430ed155f0f94f52e944bf2785b2a.sif
        ├── cooler
        │   ├── 0.8.11--pyh3252c3a_0
        │   │   └── quay.io-biocontainers-cooler-0.8.11--pyh3252c3a_0-sha256:c954780cf75fd8fe026de342253982a354b6211258e45f66e18d08af68271138.sif
        │   └── 0.8.6--py_0
        │       └── quay.io-biocontainers-cooler-0.8.6--py_0-sha256:1b0e2e9625d9d0beee5befaf866df016a80f364339fbb396ab8d84878a3a0584.sif
        └── samtools
            └── 1.15--h3843a85_0
                └── quay.io-biocontainers-samtools-1.15--h3843a85_0-sha256:d68e1b5f504dc60eb9f2a02eecbac44a63f144e7d455b3fb1a25323c667ca4c4.sif

modules/
├── golang
│   └── 1.18-rc
│       ├── 99-shpc.sh
│       ├── bin
│       │   ├── go
│       │   └── gofmt
│       └── module.tcl
└── quay.io
    └── biocontainers
        ├── bwa
        │   └── 0.7.17--h7132678_9
        │       ├── 99-shpc.sh
        │       ├── bin
        │       │   └── bwa
        │       └── module.tcl
        ├── bwa-mem2
        │   └── 2.2.1--hd03093a_2
        │       ├── 99-shpc.sh
        │       ├── bin
        │       │   └── bwa-mem2
        │       └── module.tcl
        ├── cooler
        │   ├── 0.8.11--pyh3252c3a_0
        │   │   ├── 99-shpc.sh
        │   │   ├── bin
        │   │   │   └── cooler
        │   │   └── module.tcl
        │   └── 0.8.6--py_0
        │       ├── 99-shpc.sh
        │       ├── bin
        │       │   └── cooler
        │       └── module.tcl
        └── samtools
            └── 1.15--h3843a85_0
                ├── 99-shpc.sh
                ├── bin
                │   ├── bgzip
                │   ├── htsfile
                │   ├── samtools
                │   └── tabix
                └── module.tcl

symlinks/
├── bwa
│   └── 0.7.17--h7132678_9 -> /lustre/scratch123/tol/teams/tolit/users/mm49/shpc/singularity-hpc/modules/quay.io/biocontainers/bwa/0.7.17--h7132678_9/module.tcl
├── bwa-mem2
│   └── 2.2.1--hd03093a_2 -> /lustre/scratch123/tol/teams/tolit/users/mm49/shpc/singularity-hpc/modules/quay.io/biocontainers/bwa-mem2/2.2.1--hd03093a_2/module.tcl
├── cooler
│   ├── 0.8.11--pyh3252c3a_0 -> /lustre/scratch123/tol/teams/tolit/users/mm49/shpc/singularity-hpc/modules/quay.io/biocontainers/cooler/0.8.11--pyh3252c3a_0/module.tcl
│   └── 0.8.6--py_0 -> /lustre/scratch123/tol/teams/tolit/users/mm49/shpc/singularity-hpc/modules/quay.io/biocontainers/cooler/0.8.6--py_0/module.tcl
├── golang
│   └── 1.18-rc -> /lustre/scratch123/tol/teams/tolit/users/mm49/shpc/singularity-hpc/modules/golang/1.18-rc/module.tcl
└── samtools
    └── 1.15--h3843a85_0 -> /lustre/scratch123/tol/teams/tolit/users/mm49/shpc/singularity-hpc/modules/quay.io/biocontainers/samtools/1.15--h3843a85_0/module.tcl
```

Example `module avail` output
```
----------------------------------------------- /nfs/users/nfs_m/mm49/nfs/scratch123/shpc/singularity-hpc/modules -----------------------------------------------
golang/1.18-rc/module.tcl                                    quay.io/biocontainers/cooler/0.8.6--py_0/module.tcl           
quay.io/biocontainers/bwa-mem2/2.2.1--hd03093a_2/module.tcl  quay.io/biocontainers/cooler/0.8.11--pyh3252c3a_0/module.tcl  
quay.io/biocontainers/bwa/0.7.17--h7132678_9/module.tcl      quay.io/biocontainers/samtools/1.15--h3843a85_0/module.tcl    

---------------------------------------------- /nfs/users/nfs_m/mm49/nfs/scratch123/shpc/singularity-hpc/symlinks -----------------------------------------------
bwa-mem2/2.2.1--hd03093a_2  bwa/0.7.17--h7132678_9  cooler/0.8.6--py_0  cooler/0.8.11--pyh3252c3a_0  golang/1.18-rc  samtools/1.15--h3843a85_0  
```




Best,
Matthieu