### PR TITLE
Update documentation with minor fixes

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -80,7 +80,7 @@ variables in the config:
 .. code-block:: console
  
 
-    $ shpc config set registry:/<DIR>
+    $ shpc config add registry:/<DIR>
     $ shpc config set module_base:/<DIR> 
     $ shpc config set container_base:/<DIR> 
 

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -132,7 +132,7 @@ take preference over this one as follows:
 
 .. code-block:: console
 
-    $ shpc config userinit
+    $ shpc config inituser
 
 
 When you create a user settings file (or provide a custom settings file one off to


### PR DESCRIPTION
I noticed two minor problems when following the documentation:

1. In the config file, `registry` is a list so we need `shpc config add registry:/<DIR>` instead of `shpc config set registry:/<DIR>`
2. Initializing a config file for the user is `shpc config inituser` instead of `shpc config userinit`

I updated both in this pull request. 