### PR TITLE
If the container is deleted, the module has to be deleted too. No need to ask the user

### DIFF
--- a/shpc/main/modules/base.py
+++ b/shpc/main/modules/base.py
@@ -106,21 +106,22 @@ class ModuleBase(BaseClient):
         # Podman needs image deletion
         self.container.delete(name)
 
-        if container_dir != module_dir:
-            self._uninstall(container_dir, "$container_base/%s" % name, force)
-            self._uninstall(module_dir, "$module_base/%s" % name, force)
-        else:
-            self._uninstall(module_dir, "$module_base/%s" % name, force)
+        if not force:
+            msg = name + "?"
+            if not utils.confirm_uninstall(msg, force):
+                return
 
-    def _uninstall(self, module_dir, name, force=False):
+        if container_dir != module_dir:
+            self._uninstall(container_dir, "$container_base/%s" % name)
+            self._uninstall(module_dir, "$module_base/%s" % name)
+        else:
+            self._uninstall(module_dir, "$module_base/%s" % name)
+
+    def _uninstall(self, module_dir, name):
         """
         Sub function, so we can pass more than one folder from uninstall
         """
         if os.path.exists(module_dir):
-            if not force:
-                msg = "%s, and all content below it? " % name
-                if not utils.confirm_uninstall(msg, force):
-                    return
             self._cleanup(module_dir)
             logger.info("%s and all subdirectories have been removed." % name)
         else:

--- a/shpc/main/modules/base.py
+++ b/shpc/main/modules/base.py
@@ -117,6 +117,13 @@ class ModuleBase(BaseClient):
         else:
             self._uninstall(module_dir, "$module_base/%s" % name)
 
+        # parent of versioned directory has module .version
+        module_dir = os.path.dirname(module_dir)
+
+        # update the default version file, if other versions still present
+        if os.path.exists(module_dir):
+            self.write_version_file(module_dir)
+
     def _uninstall(self, module_dir, name):
         """
         Sub function, so we can pass more than one folder from uninstall
@@ -126,13 +133,6 @@ class ModuleBase(BaseClient):
             logger.info("%s and all subdirectories have been removed." % name)
         else:
             logger.warning("%s does not exist." % name)
-
-        # parent of versioned directory has module .version
-        module_dir = os.path.dirname(module_dir)
-
-        # update the default version file, if other versions still present
-        if os.path.exists(module_dir):
-            self.write_version_file(module_dir)
 
     def _test_setup(self, tmpdir):
         """

--- a/shpc/utils/__init__.py
+++ b/shpc/utils/__init__.py
@@ -15,6 +15,7 @@ from .fileio import (
     get_tmpfile,
     mkdir_p,
     mkdirp,
+    rmdir_to_base,
     print_json,
     read_file,
     read_json,

--- a/shpc/utils/fileio.py
+++ b/shpc/utils/fileio.py
@@ -61,6 +61,28 @@ def mkdir_p(path):
             logger.exit("Error creating path %s, exiting." % path)
 
 
+def rmdir_to_base(path, base_path):
+    """
+    Delete the tree under $path and all the parents
+    up to $base_path as long as they are empty
+    """
+    if not os.path.isdir(base_path):
+        logger.exit("Error: %s is not a directory" % base_path)
+    if not path.startswith(base_path):
+        logger.exit("Error: %s is not a parent of %s" % (base_path, path))
+
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+    # If directories above it are empty, remove
+    while path != base_path:
+        if os.path.exists(path):
+            if not can_be_deleted(path, [".version"]):
+                break
+            shutil.rmtree(path)
+        path = os.path.dirname(path)
+
+
 def get_tmpfile(tmpdir=None, prefix=""):
     """
     Get a temporary file with an optional prefix.


### PR DESCRIPTION
This is independent from the symlink and default_version business, so putting this as a separate PR.

Since a module needs its container .sif to function, if the user confirms they want to delete the container, the module would become non functional. I think it's redundant (and misleading) to ask the user if they want the module to be deleted too, `shpc uninstall` should just remove it.