### PR TITLE
pinning spython to 0.2.0 to remove singularity version checks

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Tributors Update      
-        uses: con/tributors@run-twice
+        uses: con/tributors@0.0.21
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - minimum version of spython required is 0.2.0 to support apptainer (0.0.51)
  - add support for TCL and LMOD default version, multiple variants (0.0.50)
  - refactor to "add" to generate a container.yaml first (0.0.49)
  - Properly cleanup empty module directories, and asking to remove a container that doesn't exist now logs a _warning_ (0.0.48)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![DOI](https://zenodo.org/badge/354130612.svg)](https://zenodo.org/badge/latestdoi/354130612)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.03311/status.svg)](https://doi.org/10.21105/joss.03311)
 
-
 ![https://raw.githubusercontent.com/singularityhub/singularity-hpc/main/docs/assets/img/shpc.png](https://raw.githubusercontent.com/singularityhub/singularity-hpc/main/docs/assets/img/shpc.png)
 
 Singularity HPC is optimized for managing containers in an HPC environment. Currently, this includes

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.50"
+__version__ = "0.0.51"
 AUTHOR = "Vanessa Sochat"
 NAME = "singularity-hpc"
 PACKAGE_URL = "https://github.com/singularityhub/singularity-hpc"
@@ -17,7 +17,7 @@ LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
     # 0.1.18 added support for oras
-    ("spython", {"min_version": "0.1.18"}),
+    ("spython", {"min_version": "0.2.0"}),
     ("Jinja2", {"min_version": None}),
     ("jsonschema", {"min_version": None}),
     ("ruamel.yaml", {"min_version": None}),


### PR DESCRIPTION
this use has two fold - we do not want to support singularity 2.x anymore, and
we want to (to the largest extent possible that it does not introduce complexity)
support both apptainer and singularityce as much as possible. Since they have
different versioning schemes, the checks prior to 0.2.0 would break pulls
for apptainer

Signed-off-by: vsoch <vsoch@users.noreply.github.com>