### PR TITLE
add support for depends_on in views and editor from envars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - support for system modules, depends on, in views and editor envars (0.1.13)
  - Wrappers now supported for shell/exec/run container commands (0.1.12)
  - Update add to return container yaml (0.1.11)
  - Fixing bug with writing package file in update (0.1.1)

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -867,6 +867,7 @@ we load a view module named mpi, we always want to load a system module named "o
 
 .. code-block:: console
 
+    $ shpc view add <view> system_modules <name1> <name2>
     $ shpc view add mpi system_modules openmpi mymod
     Wrote updated .view_module: /home/vanessa/Desktop/Code/shpc/views/mpi/.view_module
     
@@ -889,6 +890,43 @@ Of course an "add" command would not be complete without a "remove" command! To 
 
 Note that if you edit the files manually, you would need to edit the view.yaml AND the hidden
 .view_module that is always updated from it.
+
+
+Add and Remove Depends On Modules to a View
+-------------------------------------------
+
+You can add (or remove) a ``depends_on`` clause to a view, just like with system modules.
+The syntax is the same, however you specify a different key to add to:
+
+.. code-block:: console
+
+    $ shpc view add <view> depends_on <name1> <name2>
+    $ shpc view add mpi depends_on openmpi
+    $ shpc view remove mpi depends_on openmpi
+
+When you add a ``depends_on`` or ``system_modules`` to a view, what we are doing under
+the hood is adding a ``.view_module`` that will be loaded with the view, and it includes these
+extra parameters. 
+
+.. code-block:: console
+
+    views/
+    └── mpi
+      ├── python
+      ├── view.yaml
+      ├── .view_module
+      └── 3.11-rc.lua -> /home/vanessa/Desktop/Code/shpc/modules/python/3.11-rc/module.lua
+        
+Here are example contents of ``.view_module`` (this will vary depending on your module software):
+
+.. code-block:: tcl
+
+    module load("myextraprogram")
+    depends_on("openmpi")
+
+
+If you want any extra features added to this custom file (e.g., to support loading in a view)
+please open an issue for discussion.
 
 
 Delete a View
@@ -1018,7 +1056,8 @@ You can also open the config in the editor defined in settings at ``config_edito
     $ shpc config edit
     
 
-which defaults to vim.
+which will first look at the environment variables ``$EDITOR`` and ``$VISUAL`` and will
+fall back to the ``config_editor`` in your user settings (vim by default).
 
 .. _getting_started-commands-show:
 

--- a/shpc/main/modules/templates/view_module.lua
+++ b/shpc/main/modules/templates/view_module.lua
@@ -3,4 +3,5 @@
 --
 
 {% for module in system_modules %}
-module load("{{ module }}"){% endfor %}
+module load("{{ module }}"){% endfor %}{% for depends in depends_on %}
+depends_on("{{ depends }}"){% endfor %}

--- a/shpc/main/modules/templates/view_module.tcl
+++ b/shpc/main/modules/templates/view_module.tcl
@@ -4,5 +4,5 @@
 # View for singularity-hpc (https://github.com/singularityhub/singularity-hpc)
 #=====
 
-{% for module in system_modules %}
-module load {{ module }}{% endfor %}
+{% if system_modules %}module load {% for module in system_modules %}{{ module }} {% endfor %}{% endif %}
+{% if depends_on %}depends-on {% for depend in depends_on %}{{ depend }} {% endfor %}{% endif %}

--- a/shpc/main/modules/views.py
+++ b/shpc/main/modules/views.py
@@ -16,7 +16,7 @@ import shpc.utils as utils
 from shpc.logger import logger
 
 # Supported variables and defaults
-supported_view_variables = {"system_modules": []}
+supported_view_variables = {"system_modules": [], "depends_on": []}
 
 
 class ViewModule:
@@ -41,7 +41,8 @@ class ViewModule:
         template = self.template.load("view_module.%s" % self.module_extension)
         view_module_file = os.path.join(view_dir, ".view_module")
         out = template.render(
-            system_modules=view_config["view"].get("system_modules", [])
+            system_modules=view_config["view"].get("system_modules", []),
+            depends_on=view_config["view"].get("depends_on", []),
         )
         utils.write_file(view_module_file, out)
         logger.info("Wrote updated .view_module: %s" % view_module_file)
@@ -251,9 +252,16 @@ class ViewsHandler:
 
     def generate_view_config(self, name):
         """
-        Generate an empty view config. system_modules are not supported yet.
+        Generate an empty view config. system_modules/depends_on are not supported yet.
         """
-        cfg = {"view": {"name": name, "modules": [], "system_modules": []}}
+        cfg = {
+            "view": {
+                "name": name,
+                "modules": [],
+                "system_modules": [],
+                "depends_on": [],
+            }
+        }
         self.save_config(name, cfg)
 
 

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -193,6 +193,7 @@ settings = {
 
 viewProperties = {
     "system_modules": {"type": "array", "items": {"type": "string"}},
+    "depends_on": {"type": "array", "items": {"type": "string"}},
     "modules": {"type": "array", "items": {"type": "string"}},
     "name": {"type": "string"},
 }

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-hpc"


### PR DESCRIPTION
This will add support for `depends_on` to views, and also support for deriving the editor from the environment variables `$EDITOR` and `$VISUAL` before defaulting to the configuration editor. This will close:

- #423 
- #527 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>