### PR TITLE
Fix views system module loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - fix views .view_module modulefile and loading (0.1.14)
  - support for system modules, depends on, in views and editor envars (0.1.13)
  - Wrappers now supported for shell/exec/run container commands (0.1.12)
  - Update add to return container yaml (0.1.11)

--- a/shpc/main/modules/templates/includes/load_view.lua
+++ b/shpc/main/modules/templates/includes/load_view.lua
@@ -1,6 +1,6 @@
 local view_dir = string.gsub(myFileName():match("(.*[/])") or ".","/%a*/$","")
 local view_name = string.gsub(view_dir,".*/","")
-local view_module = '.view_' .. view_name
+local view_module = '.view_module'
 local view_modulefile = view_dir .. '/' .. view_module .. '.lua'
 
 if isFile(view_modulefile) then

--- a/shpc/main/modules/templates/includes/load_view.tcl
+++ b/shpc/main/modules/templates/includes/load_view.tcl
@@ -1,6 +1,6 @@
 set view_dir "[file dirname [file dirname ${ModulesCurrentModulefile}] ]"
 set view_name "[file tail ${view_dir}]"
-set view_module ".view_${view_name}"
+set view_module ".view_module"
 set view_modulefile "${view_dir}/${view_module}"
 
 if {[file exists ${view_modulefile}]} {

--- a/shpc/main/modules/templates/view_module.lua
+++ b/shpc/main/modules/templates/view_module.lua
@@ -3,5 +3,5 @@
 --
 
 {% for module in system_modules %}
-module load("{{ module }}"){% endfor %}{% for depends in depends_on %}
+load("{{ module }}"){% endfor %}{% for depends in depends_on %}
 depends_on("{{ depends }}"){% endfor %}

--- a/shpc/main/modules/views.py
+++ b/shpc/main/modules/views.py
@@ -39,13 +39,17 @@ class ViewModule:
         if not os.path.exists(view_dir):
             return
         template = self.template.load("view_module.%s" % self.module_extension)
-        view_module_file = os.path.join(view_dir, ".view_module")
+        modulefile_extension = ".lua" if self.module_extension == "lua" else ""
+        view_module_file = os.path.join(view_dir, 
+                              ".view_module%s" % modulefile_extension)
         out = template.render(
             system_modules=view_config["view"].get("system_modules", []),
             depends_on=view_config["view"].get("depends_on", []),
         )
         utils.write_file(view_module_file, out)
-        logger.info("Wrote updated .view_module: %s" % view_module_file)
+        logger.info("Wrote updated .view_module.%s: %s" 
+                    % (self.module_extension, view_module_file)
+                   )
 
 
 class ViewsHandler:

--- a/shpc/tests/test_views.py
+++ b/shpc/tests/test_views.py
@@ -185,7 +185,9 @@ def test_view_components(tmp_path, module_sys, module_file, container_tech, remo
 
     # Before adding any attributes, this file should not exist
     view = client.views[view_name]
-    view_module = os.path.join(view.path, ".view_module")
+    view_module_extension = ".lua" if module_sys == "lmod" else ""
+    view_module = os.path.join(view.path, ".view_module%s" 
+                          % view_module_extension)
     assert not os.path.exists(view_module)
 
     # Try adding valid attributes

--- a/shpc/tests/test_views.py
+++ b/shpc/tests/test_views.py
@@ -108,7 +108,9 @@ def test_views(tmp_path, module_sys, module_file, container_tech, remote):
     )
 
     # Before adding any attributes, this file should not exist
-    view_module = os.path.join(view.path, ".view_module")
+    view_module_extension = ".lua" if module_sys == "lmod" else ""
+    view_module = os.path.join(view.path, ".view_module%s" 
+                          % view_module_extension)
     assert not os.path.exists(view_module)
 
     # Try adding valid attributes

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-hpc"


### PR DESCRIPTION
I was unable to get views to appropriately load system modules on our cluster (ohpc stack, lmod module system). Upon digging around in the modulefiles, I think the following are the causes:

1. In `load_view.lua` and `load_view.tcl`:

```lua
local view_module = '.view_' .. view_name
```
The view_module should be just `.view_module`, not `.view_<modulename>`. This is consistent with the documentation and behavior of the rest of shpc.

2. In `load_view.lua`:

```lua
local view_modulefile = view_dir .. '/' .. view_module .. '.lua'
``` 
The modulefile is expected, correctly, to be `.view_module.lua`. However, the saved view modulefile is just `.view_module`. To fix, I updated `views.py` with the following:

```python
modulefile_extension = ".lua" if self.module_extension == "lua" else ""
view_module_file = os.path.join(view_dir, 
                        ".view_module%s" % modulefile_extension)
```

3. In `view_module.lua`:

Since this file gets `load`ed into the resulting modulefile, we need to omit `module` from `module load(...)`.

```lua
load("{{ module }}"){% endfor %}{% for depends in depends_on %}
```

I tested this locally (using lmod) and it seems fixed with these changes. Please let me know if I missed anything or completely misunderstood how to use views.

Signed-off-by: Georgia Stuart <georgia.stuart@gmail.com>