### PR TITLE
add tutorial for creating registry, cache, and using it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
   test_singularity_hpc:
     working_directory: ~/repo
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:2022.10.1
     steps:
       - run: *exit_early
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,12 +59,7 @@ build_singularity: &install_singularity
 
 install_podman: &install_podman
   name: Install Podman
-  command: |-
-    . /etc/os-release
-    sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
-    sudo apt-get update -qq
-    sudo apt-get -qq -y install podman
+  command: sudo apt-get -y install podman
 
 install_dependencies: &install_dependencies
   name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,12 @@ build_singularity: &install_singularity
 
 install_podman: &install_podman
   name: Install Podman
-  command: sudo apt-get -y install podman
+  command: |-
+    . /etc/os-release
+    sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
+    sudo apt-get update -qq
+    sudo apt-get -qq -y install podman
 
 install_dependencies: &install_dependencies
   name: install dependencies

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -68,7 +68,7 @@ jobs:
       if: ${{ env.keepgoing == 'true' }}
       name: Install Singularity
       with:
-        singularity-version: 3.6.4
+        singularity-version: 3.7.1
 
     - name: Create conda environment
       if: ${{ env.keepgoing == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       if: ${{ matrix.container_tech == 'singularity' }}
       name: Install Singularity
       with:
-        singularity-version: 3.6.4
+        singularity-version: 3.7.1
 
     - name: Create conda environment
       run: conda create --quiet -c conda-forge --name shpc spython

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The versions coincide with releases on pip. Only major versions will be released
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
  - GitHub action to update a registry from a cache or listing (0.1.17)
+   - Support for "remove" command to more easily remove / uninstall entries
  - Fix bugs uninstalling all tags of a module (0.1.16)
  - support for install using registry recipe and local image (0.1.15)
  - fix views .view_module modulefile and loading (0.1.14)

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -1040,7 +1040,7 @@ Creating a Cache
 
 Instead of manually adding entries, let's create an automated way to populate
 entries from a cache. You can read more about the algorithm we use to derive aliases
-in the ``shpc-registry-cache <https://github.com/singularityhub/shpc-registry-cache>`_
+in the `shpc-registry-cache <https://github.com/singularityhub/shpc-registry-cache>`_
 repository, along with cache generation details. You will primarily need two things:
 
 1. A text listing of containers to add to the cache, ideally automatically generated

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -20,8 +20,8 @@ you use pip or another setup approach, and to install a `known release <https://
 
 .. code:: console
 
-    # Install release 0.0.24
-    $ git clone -b 0.0.24 git@github.com:singularityhub/singularity-hpc
+    # Install release ${RELEASE}
+    $ git clone -b ${RELEASE} git@github.com:singularityhub/singularity-hpc
     $ cd singularity-hpc
     $ pip install -e .[all]
 

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -1263,6 +1263,7 @@ Namespaces currently work with:
  - uninstall
  - show
  - add
+ - remove
  - check
 
 
@@ -1890,6 +1891,34 @@ And that's it! The container module will use the same namespace, ``vanessa/pokem
 and we do this purposefully as a design decision. Note that ``add`` previously would add the container directly to the module
 directory, and as of version 0.0.49 it's been updated to generate the container.yaml first.
 
+.. _getting_started-commands-remove:
+
+Remove
+------
+
+As of version ``0.1.17`` you can easily remove a container.yaml entry too!
+This remove command takes a pattern, and not providing one will remove all entries
+from the registry (useful if you want to create a new one but preserve the automation).
+Here is how to remove a specific namespace of container yamls:
+
+.. code-block:: console
+
+    $ shpc remove quay.io/biocontainers
+    Searching for container.yaml matching quay.io/biocontainers to remove...
+    Are you sure you want to remove 8367 container.yaml recipes? (yes/no)?
+
+
+To remove all modules:
+
+.. code-block:: console
+
+    $ shpc remove
+    Searching for container yaml to remove...
+    Are you sure you want to remove 264 container.yaml recipes? (yes/no)? yes
+    Removal complete!
+
+This command can be useful if you want to start with a populated registry
+as a template for your own registry.
 
 Get
 ---

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -176,6 +176,16 @@ shpc -c rm:registry:/tmp/registry""",
         nargs="?",
     )
 
+    # Remove a container recipe
+    remove = subparsers.add_parser(
+        "remove", description="remove a container.yaml entry"
+    )
+    remove.add_argument(
+        "module_id",
+        help='desired identifier path to remove (e.g. "quay.io/biocontainers"). Leave out to remove all.',
+        nargs="?",
+    )
+
     check = subparsers.add_parser(
         "check", description="check if you have latest installed."
     )
@@ -372,6 +382,7 @@ shpc config remove registry /tmp/registry""",
         inspect,
         install,
         listing,
+        remove,
         shell,
         test,
         uninstall,
@@ -420,7 +431,7 @@ shpc config remove registry /tmp/registry""",
         dest="filter_string",
     )
 
-    for command in docgen, show, add, sync:
+    for command in docgen, show, add, remove, sync:
         command.add_argument(
             "--registry", help="GitHub repository or local path where registry lives."
         )
@@ -499,6 +510,8 @@ def run_shpc():
         from .namespace import main
     elif args.command == "pull":
         from .pull import main
+    elif args.command == "remove":
+        from .remove import main
     elif args.command == "shell":
         from .shell import main
     elif args.command == "show":

--- a/shpc/client/remove.py
+++ b/shpc/client/remove.py
@@ -1,0 +1,30 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2022, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+import shpc.utils
+
+
+def main(args, parser, extra, subparser):
+
+    from shpc.main import get_client
+
+    shpc.utils.ensure_no_extra(extra)
+
+    cli = get_client(
+        quiet=args.quiet,
+        settings_file=args.settings_file,
+        module_sys=args.module_sys,
+        container_tech=args.container_tech,
+    )
+
+    # Update config settings on the fly
+    cli.settings.update_params(args.config_params)
+
+    # Specify custom registry to add
+    if args.registry:
+        cli.settings.registry = [args.registry]
+        cli.reload_registry()
+
+    # No module id is akin to "remove all"
+    cli.remove(args.module_id)

--- a/shpc/main/registry/filesystem.py
+++ b/shpc/main/registry/filesystem.py
@@ -4,7 +4,6 @@ __license__ = "MPL 2.0"
 
 
 import os
-import re
 import shutil
 
 import shpc.utils
@@ -110,14 +109,10 @@ class Filesystem(Provider):
         """
         Iterate over content in filesystem registry.
         """
-        for filename in shpc.utils.recursive_find(self.source):
+        for filename in shpc.utils.recursive_find(self.source, filter_string):
             if not filename.endswith("container.yaml"):
                 continue
             module_name = (
                 os.path.dirname(filename).replace(self.source, "").strip(os.sep)
             )
-
-            # If the user has provided a filter, honor it
-            if filter_string and not re.search(filter_string, module_name):
-                continue
             yield FilesystemResult(module_name, filename)


### PR DESCRIPTION
This pull request will do the following:

- add a remove command to close #617 
- add a complete tutorial for creating a remote, a cache, and using it

It's not the easiest process, but I've worked for days fairly hard on it, and (at least beyond the registry generation) I think the actions are fairly straight forward. I'm not sure how to simplify this further, but definitely would be open to ideas (or more ideally some help!) :laughing: 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>