### PR TITLE
Change shpc edit to shpc config edit in help text

### DIFF
--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -239,7 +239,7 @@ shpc view edit <name>""",
 shpc config set key value
 shpc config set key:subkey value
 shpc config get key
-shpc edit
+shpc config edit
 shpc config inituser
 shpc config add registry /tmp/registry
 shpc config remove registry /tmp/registry""",


### PR DESCRIPTION
Super minor change. When the command `shpc config --help` is run, the options are 

```
positional arguments:
  params      Set or get a config value, edit the config, add or remove a list variable, or create a user-specific config.
              shpc config set key value
              shpc config set key:subkey value
              shpc config get key
              shpc edit
              shpc config inituser
              shpc config add registry /tmp/registry
              shpc config remove registry /tmp/registry
```

`shpc edit` is deprecated for `shpc config edit`. This pull request updates the help text to match. 