### PR TITLE
Doc update

### DIFF
--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -1087,7 +1087,14 @@ without any customization for executable discovery:
     Registry entry vanessa/salad was added! Before shpc install, edit:
     /tmp/my-registry/vanessa/salad/container.yaml
 
-You could then edit that file to your liking. If you want to pull the container
+You could then edit that file to your liking.
+
+Like for ``shpc update`` :ref:`getting_started-commands-update`, tags are automatically
+populated using `crane.ggcr.dev <https://crane.ggcr.dev/ls/quay.io/biocontainers/samtools>`_,
+which only returns the 50 latest tags and obviously can only access public images.
+If you see a ``crane digest`` error instead of tags, you'll have to populate the tags yourself.
+
+Executables are by default missing. If you want shpc
 to discover executables, you'll need to install guts:
 
 .. code-block:: console

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -1064,6 +1064,8 @@ will exist the second time when you add recipes.
 Manually Adding Registry Entries
 --------------------------------
 
+.. _getting_started-developer-manual-registry-entries:
+
 Great! Now you have an empty registry on your filesystem that will be pushed to GitHub
 to serve as a remote. Make sure you are back on the main branch:
 

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -422,9 +422,12 @@ For example:
     $ cd /opt/lmod/my-registry
 
 
-And then you might want to inspect :ref:`getting_started-commands-add:` to see
-how to use shpc add to generate new container.yaml files. We are working on automation
-that can make this easier, so stay tuned for updates! After that, you'll still want to
+And then you might want to inspect :ref:`getting_started-commands-add` to see
+how to use ``shpc add`` to generate new container.yaml files.
+See :ref:`getting_started-creating-filesystem-registry` for instructions on how to
+create a registry and :ref:`getting_started-developer-manual-registry-entries` to
+populate the registry with new entries.
+After that, you'll still want to
 ensure your filesystem registry is known to shpc:
 
 .. code-block:: console


### PR DESCRIPTION
Hi !

Another doc change, since we've got some automation in place.

Also, I would like to add somewhere that `shpc add` relies on the crane service being able to query the containers, which may fail in some occasions. I'm not sure whether to put that to the user guide or developer guide. Any thoughts ?

For instance it wouldn't work for privately-hosted containers, this is what we get in the yaml file
```
crane digest gitlab-registry.internal.sanger.ac.uk/tol-it/software/bio-interproscanwrapper:5.61-93.0-ext:
    Get https://gitlab-registry.internal.sanger.ac.uk/v2/: dial tcp: lookup gitlab-registry.internal.sanger.ac.uk
    on 169.254.169.254:53: no such host
```
And I think there was another error sometimes because crane returns the top 50 tags or so, which may not include the specific tag the user may ask
