### PR TITLE
fix: podman inspect typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - Podman template bug (0.1.21)
  - Improvement to shpc help command output (0.1.2)
  - Support for remote registries on self-hosted Gitlab instances (0.1.19)
  - Support for uninstall and fixing bug in biocontainers install (0.1.18)

--- a/shpc/main/wrappers/templates/docker/inspect.sh
+++ b/shpc/main/wrappers/templates/docker/inspect.sh
@@ -1,3 +1,3 @@
 {% extends "bases/shell-script-base.sh" %}
 
-{% block content %}singularity ${PODMAN_OPTS} inspect ${PODMAN_COMMAND_OPTS}  {{ image }}{% endblock %}
+{% block content %}{{ container.command }} ${PODMAN_OPTS} inspect ${PODMAN_COMMAND_OPTS}  {{ image }}{% endblock %}

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -103,4 +103,3 @@ container_features:
             # defaults to ~/.Xauthority if set to true and the container has x11: true
   home:     # one of null, or a single path or src:dest path.
             # home: true in a container.yaml will use this path, if defines
-updated_at: '2022-08-26T20:38:06Z'

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2023, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.1.2"
+__version__ = "0.1.21"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-hpc"


### PR DESCRIPTION
The podman inspect script (generated as a wrapper script) accidentally has singularity hard coded instead of the container.command template variable. This will fix that.

This will close #641 - took all of two seconds to do!

And @shahzebsiddiqui I'm really glad you are testing podman! I think most of the work has been around Singularity, but podman is also important for HPC. Definitely let us know of any other bugs that you find!