### PR TITLE
Set ruamel.yaml version to 0.17.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,16 @@ def get_reqs(lookup=None, key="INSTALL_REQUIRES"):
         module_meta = module[1]
         if "exact_version" in module_meta:
             dependency = "%s==%s" % (module_name, module_meta["exact_version"])
-        else:
-            if "min_version" in module_meta:
-                dependency = "%s>=%s" % (module_name, module_meta["min_version"])
+        elif "min_version" in module_meta:
+            if module_meta["min_version"] is None:
+                dependency = module_name
             else:
-                if "max_version" in module_meta:
-                    dependency = "%s<=%s" % (module_name, module_meta["max_version"])
+                dependency = "%s>=%s" % (module_name, module_meta["min_version"])
+        elif "max_version" in module_meta:
+            if module_meta["max_version"] is None:
+                dependency = module_name
+            else:
+                dependency = "%s<=%s" % (module_name, module_meta["max_version"])
         install_requires.append(dependency)
     return install_requires
 

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,12 @@ def get_reqs(lookup=None, key="INSTALL_REQUIRES"):
         module_meta = module[1]
         if "exact_version" in module_meta:
             dependency = "%s==%s" % (module_name, module_meta["exact_version"])
-        elif "min_version" in module_meta:
-            if module_meta["min_version"] is None:
-                dependency = module_name
-            else:
+        else:
+            if "min_version" in module_meta:
                 dependency = "%s>=%s" % (module_name, module_meta["min_version"])
+            else:
+                if "max_version" in module_meta:
+                    dependency = "%s<=%s" % (module_name, module_meta["max_version"])
         install_requires.append(dependency)
     return install_requires
 

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = (
     ("spython", {"min_version": "0.2.0"}),
     ("Jinja2", {"min_version": None}),
     ("jsonschema", {"min_version": None}),
-    ("ruamel.yaml", {"exact_version": "0.17.21"}),
+    ("ruamel.yaml", {"max_version": "0.17.21"}),
     ("requests", {"min_version": None}),
 )
 

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = (
     ("spython", {"min_version": "0.2.0"}),
     ("Jinja2", {"min_version": None}),
     ("jsonschema", {"min_version": None}),
-    ("ruamel.yaml", {"min_version": None}),
+    ("ruamel.yaml", {"exact_version": "0.17.21"}),
     ("requests", {"min_version": None}),
 )
 


### PR DESCRIPTION
For shpc version 0.1.22, ruamel.yaml 0.17.32 (default latest) does not work. 0.17.21 has been tested and confirmed to work with shpc 0.1.22.