### PR TITLE
Adding wrapper_base to allowed_envars

### DIFF
--- a/shpc/defaults.py
+++ b/shpc/defaults.py
@@ -18,7 +18,7 @@ user_settings_file = os.path.join(
 )
 
 # variables in settings that allow environment variable expansion
-allowed_envars = ["container_base", "module_base", "views_base", "registry"]
+allowed_envars = ["container_base", "module_base", "views_base", "wrapper_base", "registry"]
 
 # The default GitHub registry with recipes (for docgen)
 github_url = "https://github.com/singularityhub/shpc-registry"


### PR DESCRIPTION
After the addition of wrapper_base option in settings.yml file when using an environment variable in the wrapper_base path the variable is not expanded correctly.

This is a PR to fix this issue by just adding wrapper_base in the allowed_envars. 