### PR TITLE
Update behaviour of `shpc config get` to only show value of key

### DIFF
--- a/shpc/client/config.py
+++ b/shpc/client/config.py
@@ -48,7 +48,8 @@ def main(args, parser, extra, subparser):
         for key in args.params:
             value = cli.settings.get(key)
             value = "Unset" if value is None else value
-            logger.info("%s %s" % (key.ljust(30), value))
+            # similar to view get in view.py
+            print(value)
 
     else:
         logger.error("%s is not a recognized command." % command)

--- a/shpc/client/config.py
+++ b/shpc/client/config.py
@@ -47,7 +47,7 @@ def main(args, parser, extra, subparser):
     elif command == "get":
         for key in args.params:
             value = cli.settings.get(key)
-            value = "is unset" if value is None else value
+            value = "Unset" if value is None else value
             logger.info("%s %s" % (key.ljust(30), value))
 
     else:


### PR DESCRIPTION
Hi @vsoch , here we go, two minimal edits in this PR.

This addresses https://github.com/singularityhub/singularity-hpc/issues/658

Note how I have not added a flag to print both value and key, as I have noticed how `shpc view get <view>` works, and realised that the new behaviour for `shpc config get <key>` actually exactly matches it, hence it is quite consistent.

Two edits, one per commit:
1. new behaviour as per subject
2. when value is not set, changed printed value from `is unset` to `Unset`, as I believe it is easier to handle (as a single string without spaces) in case the output is post-processed.

Keen on your feedback as always!