### PR TITLE
fix: filter tags to not include sbom/vex

### DIFF
--- a/.github/workflows/alert-action-updates.yaml
+++ b/.github/workflows/alert-action-updates.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Detect and Update
       uses: vsoch/action-updater@2c2216e27ee963aaa31ff0ff81de007acb84b9c2 # 0.0.11
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
   generate-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: gh-pages
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup black linter
       run: conda create --quiet --name black pyflakes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install
       run: conda create --quiet --name shpc twine

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Checkout
       if: ${{ env.keepgoing == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Make Space For Build
       if: ${{ env.keepgoing == 'true' }}
@@ -74,7 +74,7 @@ jobs:
       if: ${{ env.keepgoing == 'true' }}
       run: conda create --quiet -c conda-forge --name shpc spython
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ env.keepgoing == 'true' }}
 
     - name: Install shpc

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -27,5 +27,5 @@ jobs:
         source activate shpc
         which shpc
         cd shpc/tests
-        ln -s ~/.docker/run/docker.sock /var/run/docker.sock
+        export GITHUB_CI=yes
         pytest -sxv test_*.py

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -27,4 +27,5 @@ jobs:
         source activate shpc
         which shpc
         cd shpc/tests
+        ln -s ~/.docker/run/docker.sock /var/run/docker.sock
         pytest -sxv test_*.py

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Create conda environment
       run: conda create --quiet -c conda-forge --name shpc spython
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install shpc
       run: |
         export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Create conda environment
       run: conda create --quiet -c conda-forge --name shpc spython
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install shpc
       run: |
         export PATH="/usr/share/miniconda/bin:$PATH"

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Tributors Update
       uses: con/tributors@master
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - filter out vex and sbom tags (0.1.27)
  - unpin yaml dependency (0.1.26)
  - Change format of config command output to only show setting values, not keys, for parseability (0.1.25)
  - Allow custom location for wrapper scripts (0.1.24)

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import argparse

--- a/shpc/client/add.py
+++ b/shpc/client/add.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/check.py
+++ b/shpc/client/check.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/config.py
+++ b/shpc/client/config.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import sys

--- a/shpc/client/docgen.py
+++ b/shpc/client/docgen.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/get.py
+++ b/shpc/client/get.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/inspect.py
+++ b/shpc/client/inspect.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/install.py
+++ b/shpc/client/install.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/listing.py
+++ b/shpc/client/listing.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/namespace.py
+++ b/shpc/client/namespace.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/client/pull.py
+++ b/shpc/client/pull.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import re

--- a/shpc/client/remove.py
+++ b/shpc/client/remove.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/shell.py
+++ b/shpc/client/shell.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/show.py
+++ b/shpc/client/show.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/sync.py
+++ b/shpc/client/sync.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/client/test.py
+++ b/shpc/client/test.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/uninstall.py
+++ b/shpc/client/uninstall.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/update.py
+++ b/shpc/client/update.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import shpc.utils

--- a/shpc/client/view.py
+++ b/shpc/client/view.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2023, Vanessa Sochat"
+__copyright__ = "Copyright 2023-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/defaults.py
+++ b/shpc/defaults.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/logger.py
+++ b/shpc/logger.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import inspect

--- a/shpc/main/__init__.py
+++ b/shpc/main/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/client.py
+++ b/shpc/main/client.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/base.py
+++ b/shpc/main/container/base.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/config.py
+++ b/shpc/main/container/config.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/docker.py
+++ b/shpc/main/container/docker.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/podman.py
+++ b/shpc/main/container/podman.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/singularity.py
+++ b/shpc/main/container/singularity.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/container/update/__init__.py
+++ b/shpc/main/container/update/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from shpc.logger import logger

--- a/shpc/main/container/update/diff.py
+++ b/shpc/main/container/update/diff.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import difflib

--- a/shpc/main/container/update/docker.py
+++ b/shpc/main/container/update/docker.py
@@ -1,6 +1,8 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
+
+import re
 
 import requests
 
@@ -34,7 +36,10 @@ class DockerImage:
         """
         url = "%s/ls/%s" % (self.apiroot, self.container_name)
         response = self.get_request(url)
-        return [x.strip() for x in response.text.split("\n") if x.strip()]
+        tags = [x.strip() for x in response.text.split("\n") if x.strip()]
+        # Don't include tags for vex or sbom
+        tags = [x for x in tags if not re.search("[.](sbom|vex)$", x)]
+        return tags
 
     def manifest(self, tag):
         url = "%s/manifest/%s:%s" % (self.apiroot, self.container_name, tag)

--- a/shpc/main/container/update/versions.py
+++ b/shpc/main/container/update/versions.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import re

--- a/shpc/main/modules/base.py
+++ b/shpc/main/modules/base.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import inspect

--- a/shpc/main/modules/lmod.py
+++ b/shpc/main/modules/lmod.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from .base import ModuleBase

--- a/shpc/main/modules/module.py
+++ b/shpc/main/modules/module.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2022-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from .base import ModuleBase

--- a/shpc/main/modules/template.py
+++ b/shpc/main/modules/template.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/modules/versions.py
+++ b/shpc/main/modules/versions.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/main/modules/views.py
+++ b/shpc/main/modules/views.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2022-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/main/registry/__init__.py
+++ b/shpc/main/registry/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/registry/filesystem.py
+++ b/shpc/main/registry/filesystem.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/registry/provider.py
+++ b/shpc/main/registry/provider.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/registry/remote.py
+++ b/shpc/main/registry/remote.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/templates.py
+++ b/shpc/main/templates.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import re

--- a/shpc/main/wrappers/__init__.py
+++ b/shpc/main/wrappers/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2022-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/main/wrappers/base.py
+++ b/shpc/main/wrappers/base.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2022-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/main/wrappers/generators.py
+++ b/shpc/main/wrappers/generators.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2022-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os

--- a/shpc/tests/test_container.py
+++ b/shpc/tests/test_container.py
@@ -13,6 +13,7 @@ import shpc.main.container as container
 here = os.path.dirname(os.path.abspath(__file__))
 root = os.path.dirname(here)
 
+ci = os.environ.get("GITHUB_CI")
 
 def test_pull_gh(tmp_path):
     """
@@ -53,6 +54,7 @@ def test_podman(tmp_path):
     assert not cli.exists(result)
 
 
+@pytest.mark.skipif(ci is not None, reason="GitHub actions docker socket not working")
 def test_docker(tmp_path):
     """
     Test a singularity container command

--- a/shpc/tests/test_container.py
+++ b/shpc/tests/test_container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (C) 2021-2023 Vanessa Sochat.
+# Copyright (C) 2021-2024 Vanessa Sochat.
 
 # This Source Code Form is subject to the terms of the
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
@@ -8,12 +8,15 @@
 
 import os
 
+import pytest
+
 import shpc.main.container as container
 
 here = os.path.dirname(os.path.abspath(__file__))
 root = os.path.dirname(here)
 
 ci = os.environ.get("GITHUB_CI")
+
 
 def test_pull_gh(tmp_path):
     """

--- a/shpc/utils/fileio.py
+++ b/shpc/utils/fileio.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import errno

--- a/shpc/utils/terminal.py
+++ b/shpc/utils/terminal.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -1,8 +1,8 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2021-2023, Vanessa Sochat"
+__copyright__ = "Copyright 2021-2024, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.1.26"
+__version__ = "0.1.27"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-hpc"


### PR DESCRIPTION
now that registries are adding artifact tags (it seems nvidia is the main one for now) we need to filter them out.