### PR TITLE
Add codespell (config, precommit, workflow) and make it fix typos

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
         language: python
         types: [python]
         entry: flake8
+
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ The versions coincide with releases on pip. Only major versions will be released
    - split documentation into user and developer guide
    - added automated spell checking with crate-ci/typos
    - support for container features
-   - shpc get -e to show path to an envrironment file
+   - shpc get -e to show path to an environment file
    - added support for env section to render to bound environment file
    - added support for container features like gpu
    - allowing for a `container:tag` convention to be used for commands.

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -475,7 +475,7 @@ Templating for both wrapper script types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Note that you are free to use "snippets" and "bases" either as an inclusion or "extends" meaning you can
-easily re-use code. For example, if we have the following registered directories under ``shpc/main/wrappers/templates``
+easily reuse code. For example, if we have the following registered directories under ``shpc/main/wrappers/templates``
 for definition of bases and templates:
 
 .. code-block:: console

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -5,7 +5,7 @@ Installation
 ============
 
 Singularity Registry HPC (shpc) can be installed from pypi, or from source.
-In all cases, a module technology is required such as `lmod (install intstructions) <https://lmod.readthedocs.io/en/latest/030_installing.html>`_
+In all cases, a module technology is required such as `lmod (install instructions) <https://lmod.readthedocs.io/en/latest/030_installing.html>`_
 or `environment modules (install instructions) <https://modules.readthedocs.io/en/latest/INSTALL.html>`_.
 Having module software installed means that the ``module`` command should be on your path.
 Once you are ready to install shpc along your module software, it's recommended that you create a virtual environment, if you have not already

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -207,7 +207,7 @@ variable replacement. A summary table of variables is included below, and then f
      - Format string for module commands exec,shell,run (not aliases) can include ``{{ registry }}``, ``{{ repository }}``, ``{{ tool }}`` and ``{{ version }}``
      - ``'{{ tool }}'``
    * - bindpaths
-     - string with comma separated list of paths to binds. If set, expored to SINGULARITY_BINDPATH
+     - string with comma separated list of paths to binds. If set, exported to SINGULARITY_BINDPATH
      - null
    * - singularity_shell
      - exported to SINGULARITY_SHELL

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -415,7 +415,7 @@ any changes.
 
 It could be the case that you want to start with a remote registry, but keep it locally
 with your own changes or secrets. This is essentially turning a remote registry into a filesystem
-(local) one. The easiest thing to do here is to clone it to your filesyste, and then add to shpc as a filesystem
+(local) one. The easiest thing to do here is to clone it to your filesystem, and then add to shpc as a filesystem
 registry.
 
 .. code-block:: console
@@ -1234,7 +1234,7 @@ This feature is supported for shpc versions 0.1.15 and up.
 Namespace
 ---------
 
-Let's say that you are exclusively using continers in the namespace ghcr.io/autamus.
+Let's say that you are exclusively using containers in the namespace ghcr.io/autamus.
 
 .. code-block:: console
 

--- a/example/README.md
+++ b/example/README.md
@@ -6,7 +6,7 @@ This set of examples includes the following:
 
 The intention of this script is to instantiate a client, and then match
 containers you have in some root from [Galaxy Project Depot](https://depot.galaxyproject.org/singularity/)
-on your local filesytem to install to an shpc registry (as modules). The script
+on your local filesystem to install to an shpc registry (as modules). The script
 tries to be efficient and instantiate one remote registry that has all the containers.
 See the script header for usage examples.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -15,7 +15,7 @@ authors:
 affiliations:
  - name: Lawrence Livermore National Lab, Livermore, CA, USA
    index: 1
- - name: University of Arizona Research Computing, Tuscon, AZ, USA
+ - name: University of Arizona Research Computing, Tucson, AZ, USA
    index: 2
 date: 17 April 2021
 bibliography: paper.bib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 profile = "black"
-exclude = ["^env/"]
+exclude = "^env/"
 
 [tool.isort]
 profile = "black" # needed for black/isort compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,10 @@ exclude = ["^env/"]
 [tool.isort]
 profile = "black" # needed for black/isort compatibility
 skip = []
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,*.svg,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/shpc/client/__init__.py
+++ b/shpc/client/__init__.py
@@ -173,7 +173,7 @@ def get_parser():
         action="store_true",
     )
 
-    # Add a container direcly
+    # Add a container directly
     add = subparsers.add_parser(
         "add",
         formatter_class=argparse.RawTextHelpFormatter,

--- a/shpc/client/help.py
+++ b/shpc/client/help.py
@@ -10,7 +10,7 @@ shell_description = """Shell into a Python session with a client.
   > client
   Out[1]: [shpc-client]
 
-  # Shell into a client with a different interpeter
+  # Shell into a client with a different interpreter
   $ shpc shell -i python
   $ shpc shell -i ipython
   $ shpc shell -i bpython"""

--- a/shpc/client/shell.py
+++ b/shpc/client/shell.py
@@ -25,7 +25,7 @@ def main(args, parser, extra, subparser):
             except ImportError:
                 pass
 
-    # Otherwise present order of liklihood to have on system
+    # Otherwise present order of likelihood to have on system
     for shell in shells:
         try:
             return lookup[shell](args)

--- a/shpc/main/__init__.py
+++ b/shpc/main/__init__.py
@@ -55,7 +55,7 @@ def get_client(quiet=False, **kwargs):
 
         Client.container = DockerContainer()
 
-    # The containe should have access to settings too
+    # The container should have access to settings too
     if hasattr(Client, "container"):
         Client.container.settings = settings
 

--- a/shpc/main/modules/base.py
+++ b/shpc/main/modules/base.py
@@ -231,7 +231,7 @@ class ModuleBase(BaseClient):
         if image.startswith("docker"):
             module_name = image.replace("docker://", "")
 
-        # If we still dont' have a module name and not docker, no go
+        # If we still don't have a module name and not docker, no go
         if not module_name:
             logger.exit("A module name is required to add an image.")
         module_name = self.add_namespace(module_name)

--- a/shpc/main/modules/views.py
+++ b/shpc/main/modules/views.py
@@ -465,7 +465,7 @@ class View:
         updated = []
         change = False
         for module in self._config["view"]["modules"]:
-            # This will match an entire dirname (if all delted) or a specific version
+            # This will match an entire dirname (if all deleted) or a specific version
             if module_uid not in module:
                 updated.append(module)
             else:

--- a/shpc/main/registry/filesystem.py
+++ b/shpc/main/registry/filesystem.py
@@ -15,7 +15,7 @@ from .provider import Provider, Result
 class FilesystemResult(Result):
     """
     A filesystem result provides courtesy functions for interacting with
-    a container yaml recipe on the filesytem.
+    a container yaml recipe on the filesystem.
     """
 
     def __init__(self, module, container_yaml):

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -125,7 +125,7 @@ class SettingsBase:
         """
         Load the settings file into the settings object
         """
-        # Get the preferred settings flie
+        # Get the preferred settings file
         self.settings_file = self.get_settings_file(settings_file)
 
         # Exit quickly if the settings file does not exist

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -57,7 +57,7 @@ default_view:
 singularity_module:
 podman_module:
 
-# string with comma separated list of paths to binds. If set, expored to SINGULARITY_BINDPATH
+# string with comma separated list of paths to binds. If set, exported to SINGULARITY_BINDPATH
 bindpaths:
 
 # for container technologies that can specify a tty input (e.g., -t)


### PR DESCRIPTION
TODO
- [ ] remove workflow if another CI catches typo via pre-commit)