### PR TITLE
Make "module-info shell" Tcl test compatible with Lmod<=8.7.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-hpc/tree/main) (0.0.x)
+ - Fix `module-info shell` Tcl test for Lmod<=8.7.55 (0.1.30)
  - Allow import of LooseVersion from packaging (bug) (0.1.29)
  - use quay.io api to list tags since does not conform to oci (0.1.28)
  - filter out vex and sbom tags (0.1.27)

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -86,7 +86,7 @@ set inspectCmd "{{ command }} \${PODMAN_OPTS} inspect ${containerPath}"
 {% if wrapper_scripts %}prepend-path PATH ${wrapperDir}/bin{% endif %}
 
 # "aliases" to module commands
-{% if aliases %}if { [ module-info shell bash ] } {
+{% if aliases %}if { [ module-info shell ] eq {bash} } {
   if { [ module-info mode load ] } {
 {% for alias in aliases %}{% if alias.name not in wrapper_scripts %}    puts stdout "function {{ alias.name }}() { ${execCmd} {% if alias.docker_options %} {{ alias.docker_options | replace("$", "\$") }} {% endif %} --entrypoint {{ alias.entrypoint | replace("$", "\$") }} ${containerPath} {{ alias.args | replace("$", "\$") }} \"\$@\"; }; export -f {{ alias.name }};"{% endif %}
 {% endfor %}
@@ -106,14 +106,14 @@ set-alias {|module_name|}-container "echo ${containerPath}"
 set-alias {|module_name|}-shell "${shellCmd}"
 
 # A customizable exec function
-if { [ module-info shell bash ] } {
+if { [ module-info shell ] eq {bash} } {
   set-alias {|module_name|}-exec "${execCmd} --entrypoint \"\" ${containerPath} \"\$@\""
 } else {
   set-alias {|module_name|}-exec "${execCmd} --entrypoint \"\" ${containerPath}"
 }
 
 # Always provide a container run
-if { [ module-info shell bash ] } {
+if { [ module-info shell ] eq {bash} } {
   set-alias {|module_name|}-run "${runCmd} \"\$@\""
 } else {
   set-alias {|module_name|}-run "${runCmd}"

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -92,7 +92,7 @@ set inspectCmd "singularity \${SINGULARITY_OPTS} inspect \${SINGULARITY_COMMAND_
 {% if wrapper_scripts %}prepend-path PATH ${wrapperDir}/bin{% endif %}
 
 # "aliases" to module commands
-{% if aliases %}if { [ module-info shell bash ] } {
+{% if aliases %}if { [ module-info shell ] eq {bash} } {
   if { [ module-info mode load ] } {
 {% for alias in aliases %} {% if alias.name not in wrapper_scripts %}    puts stdout "function {{ alias.name }}() { ${execCmd} {% if alias.singularity_options %} {{ alias.singularity_options | replace("$", "\$") }} {% endif %} ${containerPath} {{ alias.command | replace("$", "\$") }} \"\$@\"; }; export -f {{ alias.name }};"{% endif %}
 {% endfor %}
@@ -111,14 +111,14 @@ set-alias {|module_name|}-shell "${shellCmd}"
 set-alias {|module_name|}-container "echo ${containerPath}"
 
 
-if { [ module-info shell bash ] } {
+if { [ module-info shell ] eq {bash} } {
   set-alias {|module_name|}-exec "${execCmd} ${containerPath} \"\$@\""
 } else {
   set-alias {|module_name|}-exec "${execCmd} ${containerPath}"
 }
 
 # Always provide a container run
-if { [ module-info shell bash ] } {
+if { [ module-info shell ] eq {bash} } {
   set-alias {|module_name|}-run "${runCmd} \"\$@\""
 } else {
   set-alias {|module_name|}-run "${runCmd}"

--- a/shpc/version.py
+++ b/shpc/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2021-2025, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.1.29"
+__version__ = "0.1.30"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-hpc"


### PR DESCRIPTION
Up to Lmod 8.7.55, the Tcl command "module-info shell" only returns the current shell name and cannot test if a given string corresponds this current shell.

A patch is now merged on Lmod, so newer version (8.7.56+) will cope with the "module-info shell bash" syntax.

But in the mean time, I propose here to use a test Tcl syntax that will be compatible with both Lmod and Environment Modules: "[module-info shell] eq {bash}".

This change may only be of help for people willing to use the Tcl modules produced by SHPC with the Lmod module tool.